### PR TITLE
Use list title when display a user field form

### DIFF
--- a/views/components/userfieldsform.blade.php
+++ b/views/components/userfieldsform.blade.php
@@ -76,7 +76,7 @@
 	</div>
 	@elseif($userfield->type == \Grocy\Services\UserfieldsService::USERFIELD_TYPE_PRESET_LIST)
 	<div class="form-group">
-		<label for="{{ $userfield->name }}">{{ $__t('Product group') }}</label>
+		<label for="{{ $userfield->name }}">{{ $userfield->caption }}</label>
 		<select class="form-control userfield-input" data-userfield-name="{{ $userfield->name }}">
 			<option></option>
 			@foreach(preg_split('/\r\n|\r|\n/', $userfield->config) as $option)


### PR DESCRIPTION
To replace the default string `Product group`