### PR TITLE
Fixes typo in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,15 +10,15 @@ shopt -s extglob
 pushd `dirname $0` > /dev/null
 
 backupBundleFileName="backup-`date +%d-%m-%Y-%H-%M-%S`.tgz"
-echo Making a backup of the current installation in /data/backups/$backupBundleFileName
+echo Making a backup of the current installation in ./data/backups/$backupBundleFileName
 mkdir -p ./data/backups > /dev/null
 tar -zcvf ./data/backups/$backupBundleFileName --exclude ./data/backups . > /dev/null
 find ./data/backups/*.tgz -mtime +60 -type f -delete
 
-echo Deleting everything except /data and this script
+echo Deleting everything except ./data and this script
 rm -rf !(data|update.sh) > /dev/null
 
-echo Emptying /data/viewcache
+echo Emptying ./data/viewcache
 rm -rf ./data/viewcache/* > /dev/null
 
 echo Downloading latest release


### PR DESCRIPTION
Printed paths did not contain the leading dot for the current directory such that users might be confused by the shown absolute paths (which are not absolute but relative to the script).