### PR TITLE
Add a very simple javascript-only shopping list that works offline

### DIFF
--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -81,6 +81,25 @@ class StockController extends BaseController
 		]);
 	}
 
+	public function OfflineShoppingList(\Slim\Http\Request $request, \Slim\Http\Response $response, array $args)
+	{
+		$listId = 1;
+		if (isset($request->getQueryParams()['list']))
+		{
+			$listId = $request->getQueryParams()['list'];
+		}
+
+		return $this->AppContainer->view->render($response, 'offlineshoppinglist', [
+			'listItems' => $this->Database->shopping_list()->where('shopping_list_id = :1', $listId),
+			'products' => $this->Database->products()->orderBy('name'),
+			'quantityunits' => $this->Database->quantity_units()->orderBy('name'),
+			'missingProducts' => $this->StockService->GetMissingProducts(),
+			'productGroups' => $this->Database->product_groups()->orderBy('name'),
+			'shoppingLists' => $this->Database->shopping_lists()->orderBy('name'),
+			'selectedShoppingListId' => $listId
+		]);
+	}
+
 	public function ProductsList(\Slim\Http\Request $request, \Slim\Http\Response $response, array $args)
 	{
 		return $this->AppContainer->view->render($response, 'products', [

--- a/routes.php
+++ b/routes.php
@@ -50,6 +50,7 @@ $app->group('', function()
 		$this->get('/shoppinglist', '\Grocy\Controllers\StockController:ShoppingList');
 		$this->get('/shoppinglistitem/{itemId}', '\Grocy\Controllers\StockController:ShoppingListItemEditForm');
 		$this->get('/shoppinglist/{listId}', '\Grocy\Controllers\StockController:ShoppingListEditForm');
+		$this->get('/offlineshoppinglist', '\Grocy\Controllers\StockController:OfflineShoppingList');
 	}
 
 	// Recipe routes
@@ -99,7 +100,7 @@ $app->group('', function()
 		$this->get('/equipment', '\Grocy\Controllers\EquipmentController:Overview');
 		$this->get('/equipment/{equipmentId}', '\Grocy\Controllers\EquipmentController:EditForm');
 	}
-	
+
 	// Calendar routes
 	if (GROCY_FEATURE_FLAG_CALENDAR)
 	{
@@ -119,9 +120,9 @@ $app->group('/api', function()
 
 	// System
 	$this->get('/system/info', '\Grocy\Controllers\SystemApiController:GetSystemInfo');
-	$this->get('/system/db-changed-time', '\Grocy\Controllers\SystemApiController:GetDbChangedTime');	
+	$this->get('/system/db-changed-time', '\Grocy\Controllers\SystemApiController:GetDbChangedTime');
 	$this->post('/system/log-missing-localization', '\Grocy\Controllers\SystemApiController:LogMissingLocalization');
-	
+
 	// Generic entity interaction
 	$this->get('/objects/{entity}', '\Grocy\Controllers\GenericEntityApiController:GetObjects');
 	$this->get('/objects/{entity}/{objectId}', '\Grocy\Controllers\GenericEntityApiController:GetObject');

--- a/views/offlineshoppinglist.blade.php
+++ b/views/offlineshoppinglist.blade.php
@@ -26,7 +26,7 @@
 
 @section('content')
 	<h2>Offline {{$__t('Shopping list')}}</h2>
-<table id="shoppinglist-table" class="table table-sm table-striped">
+<table id="shoppinglist-table" class="table table-striped">
 	<thead>
 	<tr>
 		<th class="border-right d-none"></th>

--- a/views/offlineshoppinglist.blade.php
+++ b/views/offlineshoppinglist.blade.php
@@ -1,0 +1,59 @@
+@extends('layout.default')
+
+@section('title', $__t('Shopping list'))
+@section('activeNav', 'shoppinglist')
+@section('viewJsName', 'shoppinglist')
+
+@push('pageScripts')
+	<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
+	<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
+	<script>
+		$('.item-row').click(function (id){
+			$(this).toggleClass('text-strike-through bg-secondary text-light');
+		});
+
+		// Set this page to a fullscreen card to prevent auto-reloading on database change events
+		$('body').addClass('fullscreen-card');
+
+		// Ask for confirmation if user wants to leave. Data is not saved.
+		$(window).bind('beforeunload', function(){ return ''});
+	</script>
+@endpush
+
+@push('pageStyles')
+	<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}" rel="stylesheet">
+@endpush
+
+@section('content')
+	<h2>Offline {{$__t('Shopping list')}}</h2>
+<table id="shoppinglist-table" class="table table-sm table-striped">
+	<thead>
+	<tr>
+		<th class="border-right d-none"></th>
+		<th>{{ $__t('Product') }} / <em>{{ $__t('Note') }}</em></th>
+		<th>{{ $__t('Amount') }}</th>
+		<th class="d-none">Hiden product group</th>
+		<th class="d-none">Hidden status</th>
+	</tr>
+	</thead>
+	<tbody class="d-none">
+	@foreach($listItems as $listItem)
+		<tr id="shoppinglistitem-{{ $listItem->id }}-row" class="item-row">
+			<td class="d-none"></td>
+			<td>
+				@if(!empty($listItem->product_id)) {{ FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->name }}<br>@else<em>{!! nl2br($listItem->note) !!}</em>@endif
+			</td>
+			<td>
+				{{ $listItem->amount }} @if(!empty($listItem->product_id)){{ $__n($listItem->amount, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->qu_id_purchase)->name, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->qu_id_purchase)->name_plural) }}@endif
+			</td>
+			<td class="d-none">
+				@if(!empty(FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->product_group_id)) {{ FindObjectInArrayByPropertyValue($productGroups, 'id', FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->product_group_id)->name }} @else <span class="font-italic font-weight-light">{{ $__t('Ungrouped') }}</span> @endif
+			</td>
+			<td class="d-none">
+				@if(FindObjectInArrayByPropertyValue($missingProducts, 'id', $listItem->product_id) !== null) belowminstockamount @endif
+			</td>
+		</tr>
+	@endforeach
+	</tbody>
+</table>
+@stop

--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -23,6 +23,9 @@
 			<a class="btn btn-outline-dark responsive-button" href="{{ $U('/shoppinglistitem/new?list=' . $selectedShoppingListId) }}">
 				<i class="fas fa-plus"></i> {{ $__t('Add item') }}
 			</a>
+			<a class="btn btn-outline-dark responsive-button @if($listItems->count() == 0) disabled @endif" href="{{ $U('/offlineshoppinglist?list=' . $selectedShoppingListId) }}">
+				<i class="fas fa-clipboard-check"></i> Offline {{ $__t('Shopping list') }}
+			</a>
 			<a id="clear-shopping-list" class="btn btn-outline-danger responsive-button @if($listItems->count() == 0) disabled @endif" href="#">
 				<i class="fas fa-trash"></i> {{ $__t('Clear list') }}
 			</a>


### PR DESCRIPTION
The OfflineShoppingList disables auto-reloading by adding the 'fullscreen-card' class to the body. It also requests a confirmation on leaving the page because nothing is saved, not even into the local or session storage. Please consider this feature as a rough draft and foundation for discussion.

I really like the checkbox of the default shopping list, because it works with multiple users at once and everyone gets synced the updates. The space, on the other hand, is really rare because of all the other buttons that are not useful when being shopping right now. Maybe we can combine the features somehow. I still don't know how we could handle this when being offline or not connected to the home network by VPN. How do you handle shopping trips?