### PR TITLE
Fixed API call AddProductToShoppingList

### DIFF
--- a/services/StockService.php
+++ b/services/StockService.php
@@ -592,7 +592,7 @@ class StockService extends BaseService
 		else // Insert
 		{
 			$shoppinglistRow = $this->Database->shopping_list()->createRow(array(
-				'product_id' => $productId->id,
+				'product_id' => $productId,
 				'amount' => $amount,
 				'shopping_list_id' => $listId
 			));


### PR DESCRIPTION
$productId->id was undefined, therefore all items added to the shopping list with the API call had a null entry for "product_id" if the item was not on the shopping list already

Sorry, apparently I had this bug in my original PR, I must have somehow missed this during testing