### PR TITLE
Rename location to "Default location" on product page

### DIFF
--- a/localization/en/strings.po
+++ b/localization/en/strings.po
@@ -159,6 +159,9 @@ msgstr "Add"
 msgid "Name"
 msgstr "Name"
 
+msgid "Default location"
+msgstr "Default location"
+
 msgid "Location"
 msgstr "Location"
 

--- a/localization/en/strings.po
+++ b/localization/en/strings.po
@@ -159,9 +159,6 @@ msgstr "Add"
 msgid "Name"
 msgstr "Name"
 
-msgid "Default location"
-msgstr "Default location"
-
 msgid "Location"
 msgstr "Location"
 

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1210,6 +1210,9 @@ msgstr ""
 msgid "Expiring soon days"
 msgstr ""
 
+msgid "Default location"
+msgstr ""
+
 msgid "Default amount for purchase"
 msgstr ""
 

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -75,7 +75,7 @@
 
 			@if(GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING)
 			<div class="form-group">
-				<label for="location_id">{{ $__t('Location') }}</label>
+				<label for="location_id">{{ $__t('Default location') }}</label>
 				<select required class="form-control" id="location_id" name="location_id">
 					<option></option>
 					@foreach($locations as $location)


### PR DESCRIPTION
Given that the location can be set on the purchase page, I thought it was more appropriate to list this as "Default location".

I wasn't sure how the translations work, so if I need to make a change to a different file please let me know.