### PR TITLE
Add GET parameter to close window after product creation

### DIFF
--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -70,7 +70,7 @@
 						/* If the GET parameter "closeAfterCreation" was passed to the form, it will
                                                    automatically close after creating the product. This only works if the window
                                                    was opened with javascript */
-						if (window.location.href.includes("closeAfterCreation"))
+						if (window.location.href.toLowerCase().includes("closeaftercreation"))
                                                 {
                                                         window.close();
                                                 }

--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -67,11 +67,14 @@
 					}
 					else
 					{
+						/* If the GET parameter "closeAfterCreation" was passed to the form, it will
+                                                   automatically close after creating the product. This only works if the window
+                                                   was opened with javascript */
 						if (window.location.href.includes("closeAfterCreation"))
                                                 {
                                                         window.close();
                                                 }
-                                                else if (redirectDestination == "reload")
+                                                if (redirectDestination == "reload")
 						{
 							window.location.reload();
 						}

--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -67,7 +67,11 @@
 					}
 					else
 					{
-						if (redirectDestination == "reload")
+						if (window.location.href.includes("closeAfterCreation"))
+                                                {
+                                                        window.close();
+                                                }
+                                                else if (redirectDestination == "reload")
 						{
 							window.location.reload();
 						}


### PR DESCRIPTION
PR for issue #419 

This only works when the window was opened by Javascript (eg. from a third party plugin like Barcode Buddy)

Closes #419