### PR TITLE
Improve mobile performance on stock overview

### DIFF
--- a/public/viewjs/stockoverview.js
+++ b/public/viewjs/stockoverview.js
@@ -1,5 +1,7 @@
 ﻿var stockOverviewTable = $('#stock-overview-table').DataTable({
 	'paginate': false,
+	'deferRender': true,
+	'searchDelay': 200,
 	'order': [[3, 'asc']],
 	'columnDefs': [
 		{ 'orderable': false, 'targets': 0 },


### PR DESCRIPTION
I have 143 products and 442 units on stock overview, when I search on my phone the page performance is really poor - this aims to alleviate that.