### PR TITLE
Set reasonable Step for Currency

### DIFF
--- a/views/inventory.blade.php
+++ b/views/inventory.blade.php
@@ -59,7 +59,7 @@
 				'id' => 'price',
 				'label' => 'Price',
 				'min' => 0,
-				'step' => 0.0001,
+				'step' => 0.01,
 				'value' => '',
 				'hint' => $__t('in %s per purchase quantity unit', GROCY_CURRENCY),
 				'additionalHtmlContextHelp' => '<br><span class="small text-muted">' . $__t('This will apply to added products') . '</span>',


### PR DESCRIPTION
@berrnd, Feel free to reject and close this PR this if you have a particular reason for setting it to `0.0001`, but it appeared super random and was super easy to alter so I thought I'd give this a shot. 

Adjusts currency selector step from `$0.0001` to `$0.01`

Fixes #435 