### PR TITLE
Recipe form updates

### DIFF
--- a/public/viewjs/recipeform.js
+++ b/public/viewjs/recipeform.js
@@ -343,7 +343,7 @@ $(window).on("message", function(e)
 
 	if (data.Message === "IngredientsChanged")
 	{
-		window.location.reload(true);
+		window.location.href = U('/recipe/' + Grocy.EditObjectId);
 	}
 
 });

--- a/public/viewjs/recipeform.js
+++ b/public/viewjs/recipeform.js
@@ -243,16 +243,24 @@ $(document).on('click', '.recipe-include-edit-button', function (e)
 
 $("#recipe-pos-add-button").on("click", function(e)
 {
-	Grocy.Api.Put('objects/recipes/' + Grocy.EditObjectId, $('#recipe-form').serializeJSON(),
-		function(result)
-		{
-			window.location.href = U('/recipe/' + Grocy.EditObjectId + '/pos/new');
-		},
-		function(xhr)
-		{
-			console.error(xhr);
+	e.preventDefault();
+
+	bootbox.dialog({
+		message: '<iframe height="650px" class="embed-responsive" src="' + U("/recipe/") + Grocy.EditObjectId + '/pos/new?embedded"></iframe>',
+		size: 'large',
+		backdrop: true,
+		closeButton: false,
+		buttons: {
+			cancel: {
+				label: __t('Cancel'),
+				className: 'btn-secondary responsive-button',
+				callback: function()
+				{
+					bootbox.hideAll();
+				}
+			}
 		}
-	);
+	});
 });
 
 $("#recipe-include-add-button").on("click", function(e)

--- a/public/viewjs/recipeform.js
+++ b/public/viewjs/recipeform.js
@@ -192,20 +192,29 @@ $(document).on('click', '.recipe-pos-show-note-button', function(e)
 	bootbox.alert(note);
 });
 
-$(document).on('click', '.recipe-pos-edit-button', function (e)
+$(document).on('click', '.recipe-pos-edit-button', function(e)
 {
-	var recipePosId = $(e.currentTarget).attr('data-recipe-pos-id');
+	e.preventDefault();
 
-	Grocy.Api.Put('objects/recipes/' + Grocy.EditObjectId, $('#recipe-form').serializeJSON(),
-		function(result)
-		{
-			window.location.href = U('/recipe/' + Grocy.EditObjectId + '/pos/' + recipePosId);
-		},
-		function(xhr)
-		{
-			console.error(xhr);
+	var productId = $(e.currentTarget).attr("data-product-id");
+	var recipePosId = $(e.currentTarget).attr('data-recipe-pos-id');
+	
+	bootbox.dialog({
+		message: '<iframe height="650px" class="embed-responsive" src="' + U("/recipe/") + Grocy.EditObjectId.toString() + '/pos/' + recipePosId.toString()  + '?embedded&product=' + productId.toString() + '"></iframe>',
+		size: 'large',
+		backdrop: true,
+		closeButton: false,
+		buttons: {
+			cancel: {
+				label: __t('Cancel'),
+				className: 'btn-secondary responsive-button',
+				callback: function()
+				{
+					bootbox.hideAll();
+				}
+			}
 		}
-	);
+	});
 });
 
 $(document).on('click', '.recipe-include-edit-button', function (e)

--- a/public/viewjs/recipeform.js
+++ b/public/viewjs/recipeform.js
@@ -336,3 +336,14 @@ $('#delete-current-recipe-picture-button').on('click', function (e)
 });
 
 Grocy.Components.UserfieldsForm.Load();
+
+$(window).on("message", function(e)
+{
+	var data = e.originalEvent.data;
+
+	if (data.Message === "IngredientsChanged")
+	{
+		window.location.reload(true);
+	}
+
+});

--- a/public/viewjs/recipeposform.js
+++ b/public/viewjs/recipeposform.js
@@ -152,5 +152,5 @@ $("#only_check_single_unit_in_stock").on("click", function()
 });
 
 // Click twice to trigger on-click but not change the actual checked state
-$("#only_check_single_unit_in_stock").click();
-$("#only_check_single_unit_in_stock").click();
+//$("#only_check_single_unit_in_stock").click();
+//$("#only_check_single_unit_in_stock").click();

--- a/public/viewjs/recipeposform.js
+++ b/public/viewjs/recipeposform.js
@@ -15,7 +15,8 @@ $('#save-recipe-pos-button').on('click', function (e)
 		Grocy.Api.Post('objects/recipes_pos', jsonData,
 			function(result)
 			{
-				window.location.href = U('/recipe/' + Grocy.EditObjectParentId);
+				window.parent.postMessage(WindowMessageBag("IngredientsChanged"), Grocy.BaseUrl);
+				window.parent.postMessage(WindowMessageBag("CloseAllModals"), Grocy.BaseUrl);
 			},
 			function(xhr)
 			{
@@ -29,7 +30,8 @@ $('#save-recipe-pos-button').on('click', function (e)
 		Grocy.Api.Put('objects/recipes_pos/' + Grocy.EditObjectId, jsonData,
 			function(result)
 			{
-				window.location.href = U('/recipe/' + Grocy.EditObjectParentId);
+				window.parent.postMessage(WindowMessageBag("IngredientsChanged"), Grocy.BaseUrl);
+				window.parent.postMessage(WindowMessageBag("CloseAllModals"), Grocy.BaseUrl);
 			},
 			function(xhr)
 			{

--- a/views/recipeform.blade.php
+++ b/views/recipeform.blade.php
@@ -98,7 +98,7 @@
 			<div class="col">
 				<h2>
 					{{ $__t('Ingredients list') }}
-					<a id="recipe-pos-add-button" class="btn btn-outline-dark" href="#">
+					<a id="recipe-pos-add-button" class="btn btn-outline-dark recipe-pos-add-button" type="button" href="#">
 						<i class="fas fa-plus"></i> {{ $__t('Add') }}
 					</a>
 				</h2>
@@ -118,7 +118,7 @@
 						@foreach($recipePositions as $recipePosition)
 						<tr>
 							<td class="fit-content border-right">
-								<a class="btn btn-sm btn-info recipe-pos-edit-button" href="#" data-recipe-pos-id="{{ $recipePosition->id }}">
+								<a class="btn btn-sm btn-info recipe-pos-edit-button" type="button" href="#" data-recipe-pos-id="{{ $recipePosition->id }}" data-product-id="{{ $recipePosition->product_id }}">
 									<i class="fas fa-edit"></i>
 								</a>
 								<a class="btn btn-sm btn-danger recipe-pos-delete-button" href="#" data-recipe-pos-id="{{ $recipePosition->id }}" data-recipe-pos-name="{{ FindObjectInArrayByPropertyValue($products, 'id', $recipePosition->product_id)->name }}">

--- a/views/recipeposform.blade.php
+++ b/views/recipeposform.blade.php
@@ -28,11 +28,9 @@
 
 		<form id="recipe-pos-form" novalidate>
 
-			@php $prefillByName = ''; if($mode=='edit') { $prefillByName = FindObjectInArrayByPropertyValue($products, 'id', $recipePos->product_id)->name; } @endphp
 			@include('components.productpicker', array(
 				'products' => $products,
-				'nextInputSelector' => '#amount',
-				'prefillByName' => $prefillByName
+				'nextInputSelector' => '#amount'
 			))
 
 			@php if($mode == 'edit') { $value = $recipePos->amount; } else { $value = 1; } @endphp

--- a/views/recipeposform.blade.php
+++ b/views/recipeposform.blade.php
@@ -96,7 +96,7 @@
 		</form>
 	</div>
 
-	<div class="col-xs-12 col-md-6 col-xl-4">
+	<div class="col-xs-12 col-md-6 col-xl-4 hide-when-embedded">
 		@include('components.productcard')
 	</div>
 </div>


### PR DESCRIPTION
For the Recipe Ingredient Add and Edit buttons I moved them to instead be bootbox as you have elsewhere.

Edit Ingredient will use the prefill by id. Fixes #475 
I didn't see anywhere else using prefill by name?

Upon success it will currently just reload the page instead of building out a Refresh method.