### PR TITLE
product in mealplan

### DIFF
--- a/migrations/0096.sql
+++ b/migrations/0096.sql
@@ -6,6 +6,7 @@ CREATE TABLE meal_plan (
 	id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,
 	day DATE NOT NULL,
 	type TEXT DEFAULT 'recipe',
+	product_id INTEGER,
 	recipe_id INTEGER,
 	recipe_servings INTEGER DEFAULT 1,
 	note TEXT,

--- a/public/viewjs/mealplan.js
+++ b/public/viewjs/mealplan.js
@@ -215,6 +215,7 @@ $(document).on("click", ".add-recipe-button", function(e)
 	$("#add-recipe-modal-title").text(__t("Add recipe to %s", day.toString()));
 	$("#day").val(day.toString());
 	Grocy.Components.RecipePicker.Clear();
+	Grocy.Components.ProductPicker.Clear();
 	$("#add-recipe-modal").modal("show");
 	Grocy.FrontendHelpers.ValidateForm("add-recipe-form");
 });
@@ -538,6 +539,27 @@ $(window).on("resize", function()
 		calendar.fullCalendar("changeView", "basicWeek");
 	}
 });
+
+Grocy.Components.ProductPicker.GetPicker().on('change', function(e)
+{
+	var productId = $(e.target).val();
+
+	if (productId)
+	{
+		Grocy.Components.RecipePicker.SetValue('');
+	}
+});
+
+Grocy.Components.RecipePicker.GetPicker().on('change', function(e)
+{
+        var recipeId = $(e.target).val();
+
+        if (recipeId)
+        {
+                Grocy.Components.ProductPicker.SetValue('');
+        }
+});
+
 function UndoStockTransaction(transactionId)
 {
 	Grocy.Api.Post('stock/transactions/' + transactionId.toString() + '/undo', { },

--- a/public/viewjs/mealplan.js
+++ b/public/viewjs/mealplan.js
@@ -306,7 +306,7 @@ Grocy.Components.RecipePicker.GetInputElement().keydown(function(event)
 	}
 });
 
-$(document).on("keyodwn", "#servings", function(e)
+$(document).on("keydown", "#servings", function(e)
 {
 	if (event.keyCode === 13) //Enter
 	{

--- a/views/mealplan.blade.php
+++ b/views/mealplan.blade.php
@@ -45,7 +45,14 @@
 
 					@include('components.recipepicker', array(
 						'recipes' => $recipes,
-						'isRequired' => true,
+						'isRequired' => false,
+						'nextInputSelector' => '#recipe_servings'
+					))
+
+					@include('components.productpicker', array(
+						'products' => $products,
+						'isRequired' => false,
+						'disallowAllProductWorkflows' => true,
 						'nextInputSelector' => '#recipe_servings'
 					))
 
@@ -58,7 +65,6 @@
 					))
 
 					<input type="hidden" id="day" name="day" value="">
-					<input type="hidden" name="type" value="recipe">
 
 				</form>
 			</div>


### PR DESCRIPTION
#450 

Now that recipes can create products then adding products to meal plans will be useful and would be nice to have for the release.

This is a work in progress commit not quite up to master just to show the work if you want to take it a bit further. It's almost there.

It may be useful to add a new product db column called ?"include_in_mealplan"? that way products can be limited in the mealplan dropdown. This would be a checkbox option on the product creation/edit pages.