### PR TITLE
389 Display ingredient amount as fractions

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -101,6 +101,7 @@ DefaultUserSetting('shopping_list_disable_auto_compact_view_on_mobile', false);
 
 # Recipe settings
 DefaultUserSetting('recipe_ingredients_group_by_product_group', false); // Group recipe ingredients by their product group
+DefaultUserSetting('recipe_ingredient_display_as_fractions', false); // Display the ingredient amounts as fractions
 
 # Chores settings
 DefaultUserSetting('chores_due_soon_days', 5);

--- a/helpers/extensions.php
+++ b/helpers/extensions.php
@@ -236,3 +236,62 @@ function string_ends_with($haystack, $needle)
 
 	return (substr($haystack, -$length) === $needle);
 }
+
+function FractionToDecimal($fraction)
+{
+	// Split fraction into whole number and fraction components
+	preg_match('/^(?P<whole>\d+)?\s?((?P<numerator>\d+)\/(?P<denominator>\d+))?$/', $fraction, $components);
+
+	// Extract whole number, numerator, and denominator components
+	$whole = $components['whole'] ?: 0;
+	$numerator = $components['numerator'] ?: 0;
+	$denominator = $components['denominator'] ?: 0;
+
+	// Create decimal value
+	$decimal = $whole;
+	$numerator && $denominator && $decimal += ($numerator/$denominator);
+
+	return $decimal;
+}
+
+function DecimalToFraction($decimal)
+{
+	// Determine decimal precision and extrapolate multiplier required to convert to integer
+	$precision = strpos(strrev($decimal), '.') ?: 0;
+	$multiplier = pow(10, $precision);
+
+	// Calculate initial numerator and denominator
+	$numerator = $decimal * $multiplier;
+	$denominator = 1 * $multiplier;
+
+	// Extract whole number from numerator
+	$whole = floor($numerator / $denominator);
+	$decimal = $decimal - $whole;
+
+	//round to manage 1/3
+	$tolerance = 1.e-4;
+
+	$h2 = 0;
+	$numerator = 1;
+	$denominator = 0;
+	$k2 = 1;
+	$b = 1 / $decimal;
+	do {
+		$b = 1 / $b;
+		$a = floor($b);
+		$aux = $numerator;
+		$numerator = $a * $numerator + $h2;
+		$h2 = $aux;
+		$aux = $denominator;
+		$denominator = $a * $denominator + $k2;
+		$k2 = $aux;
+		$b = $b - $a;
+	} while (abs($decimal - $numerator / $denominator) > $decimal * $tolerance);
+
+	// Create fraction value
+	$fraction = [];
+	$whole && $fraction[] = $whole;
+	$numerator && $fraction[] = "{$numerator}/{$denominator}";
+
+	return implode(' ', $fraction);
+}

--- a/public/viewjs/recipessettings.js
+++ b/public/viewjs/recipessettings.js
@@ -2,3 +2,7 @@
 {
 	$("#recipe_ingredients_group_by_product_group").prop("checked", true);
 }
+if (BoolVal(Grocy.UserSettings.recipe_ingredient_display_as_fractions))
+{
+	$("#recipe_ingredient_display_as_fractions").prop("checked", true);
+}

--- a/services/StockService.php
+++ b/services/StockService.php
@@ -377,27 +377,53 @@ class StockService extends BaseService
 				{
 					$restStockAmount = $stockEntry->amount - $amount;
 
-					$logRow = $this->Database->stock_log()->createRow(array(
-						'product_id' => $stockEntry->product_id,
-						'amount' => $amount * -1,
-						'best_before_date' => $stockEntry->best_before_date,
-						'purchased_date' => $stockEntry->purchased_date,
-						'used_date' => date('Y-m-d'),
-						'spoiled' => $spoiled,
-						'stock_id' => $stockEntry->stock_id,
-						'transaction_type' => $transactionType,
-						'price' => $stockEntry->price,
-						'opened_date' => $stockEntry->opened_date,
-						'recipe_id' => $recipeId,
-						'transaction_id' => $transactionId
-					));
-					$logRow->save();
+					if ($restStockAmount < 0.001) {
+						//Take the full amount if stock is less than .01
 
-					$stockEntry->update(array(
-						'amount' => $restStockAmount
-					));
+						$logRow = $this->Database->stock_log()->createRow(array(
+							'product_id' => $stockEntry->product_id,
+							'amount' => $stockEntry->amount * -1,
+							'best_before_date' => $stockEntry->best_before_date,
+							'purchased_date' => $stockEntry->purchased_date,
+							'used_date' => date('Y-m-d'),
+							'spoiled' => $spoiled,
+							'stock_id' => $stockEntry->stock_id,
+							'transaction_type' => $transactionType,
+							'price' => $stockEntry->price,
+							'opened_date' => $stockEntry->opened_date,
+							'recipe_id' => $recipeId,
+							'transaction_id' => $transactionId
+	                                        ));
+						$logRow->save();
 
-					$amount = 0;
+						$stockEntry->delete();
+
+						$amount = 0;
+					}
+					else
+					{
+						$logRow = $this->Database->stock_log()->createRow(array(
+							'product_id' => $stockEntry->product_id,
+							'amount' => $amount * -1,
+							'best_before_date' => $stockEntry->best_before_date,
+							'purchased_date' => $stockEntry->purchased_date,
+							'used_date' => date('Y-m-d'),
+							'spoiled' => $spoiled,
+							'stock_id' => $stockEntry->stock_id,
+							'transaction_type' => $transactionType,
+							'price' => $stockEntry->price,
+							'opened_date' => $stockEntry->opened_date,
+							'recipe_id' => $recipeId,
+							'transaction_id' => $transactionId
+						));
+						$logRow->save();
+
+						$stockEntry->update(array(
+							'amount' => $restStockAmount
+						));
+
+						$amount = 0;
+					}
 				}
 			}
 

--- a/views/recipeform.blade.php
+++ b/views/recipeform.blade.php
@@ -150,7 +150,11 @@
 								@if(!empty($recipePosition->variable_amount))
 									{{ $recipePosition->variable_amount }}
 								@else
-									<span class="locale-number locale-number-quantity-amount">@if($recipePosition->amount == round($recipePosition->amount)){{ round($recipePosition->amount) }}@else{{ $recipePosition->amount }}@endif</span>
+									@if(boolval($userSettings['recipe_ingredient_display_as_fractions']))
+										{{ DecimalToFraction($recipePosition->amount) }}
+									@else
+										<span class="locale-number locale-number-quantity-amount">@if($recipePosition->amount == round($recipePosition->amount)){{ round($recipePosition->amount) }}@else{{ $recipePosition->amount }}@endif</span>
+									@endif
 								@endif
 								{{ $__n($recipePosition->amount, FindObjectInArrayByPropertyValue($quantityunits, 'id', $recipePosition->qu_id)->name, FindObjectInArrayByPropertyValue($quantityunits, 'id', $recipePosition->qu_id)->name_plural) }}
 

--- a/views/recipes.blade.php
+++ b/views/recipes.blade.php
@@ -224,7 +224,11 @@
 							@if(!empty($selectedRecipePosition->recipe_variable_amount))
 								{{ $selectedRecipePosition->recipe_variable_amount }}
 							@else
-								<span class="locale-number locale-number-quantity-amount">@if($selectedRecipePosition->recipe_amount == round($selectedRecipePosition->recipe_amount, 2)){{ round($selectedRecipePosition->recipe_amount, 2) }}@else{{ $selectedRecipePosition->recipe_amount }}@endif</span>
+								@if(boolval($userSettings['recipe_ingredient_display_as_fractions']))
+									{{ DecimalToFraction($selectedRecipePosition->recipe_amount) }}
+								@else
+									<span class="locale-number locale-number-quantity-amount">@if($selectedRecipePosition->recipe_amount == round($selectedRecipePosition->recipe_amount)){{ round($selectedRecipePosition->recipe_amount) }}@else{{ $selectedRecipePosition->recipe_amount }}@endif</span>
+								@endif
 							@endif
 							{{ $__n($selectedRecipePosition->recipe_amount, FindObjectInArrayByPropertyValue($quantityUnits, 'id', $selectedRecipePosition->qu_id)->name, FindObjectInArrayByPropertyValue($quantityUnits, 'id', $selectedRecipePosition->qu_id)->name_plural) }} {{ FindObjectInArrayByPropertyValue($products, 'id', $selectedRecipePosition->product_id)->name }}
 							@if($selectedRecipePosition->need_fulfilled == 1)<i class="fas fa-check text-success"></i>@elseif($selectedRecipePosition->need_fulfilled_with_shopping_list == 1)<i class="fas fa-exclamation text-warning"></i>@else<i class="fas fa-times text-danger"></i>@endif
@@ -287,7 +291,11 @@
 						@if(!empty($selectedRecipePosition->recipe_variable_amount))
 							{{ $selectedRecipePosition->recipe_variable_amount }}
 						@else
-							<span class="locale-number locale-number-quantity-amount">@if($selectedRecipePosition->recipe_amount == round($selectedRecipePosition->recipe_amount, 2)){{ round($selectedRecipePosition->recipe_amount, 2) }}@else{{ $selectedRecipePosition->recipe_amount }}@endif</span>
+							@if(boolval($userSettings['recipe_ingredient_display_as_fractions']))
+								{{ DecimalToFraction($selectedRecipePosition->recipe_amount) }}
+							@else
+								<span class="locale-number locale-number-quantity-amount">@if($selectedRecipePosition->recipe_amount == round($selectedRecipePosition->recipe_amount)){{ round($selectedRecipePosition->recipe_amount) }}@else{{ $selectedRecipePosition->recipe_amount }}@endif</span>
+							@endif
 						@endif
 						{{ $__n($selectedRecipePosition->recipe_amount, FindObjectInArrayByPropertyValue($quantityUnits, 'id', $selectedRecipePosition->qu_id)->name, FindObjectInArrayByPropertyValue($quantityUnits, 'id', $selectedRecipePosition->qu_id)->name_plural) }} {{ FindObjectInArrayByPropertyValue($products, 'id', $selectedRecipePosition->product_id)->name }}
 						@if($selectedRecipePosition->need_fulfilled == 1)<i class="fas fa-check text-success"></i>@elseif($selectedRecipePosition->need_fulfilled_with_shopping_list == 1)<i class="fas fa-exclamation text-warning"></i>@else<i class="fas fa-times text-danger"></i>@endif

--- a/views/recipessettings.blade.php
+++ b/views/recipessettings.blade.php
@@ -18,6 +18,14 @@
 			</div>
 		</div>
 
+		<div class="form-group">
+			<div class="checkbox">
+				<label for="recipe_ingredient_display_as_fractions">
+					<input type="checkbox" class="user-setting-control" id="recipe_ingredient_display_as_fractions" name="recipe_ingredient_display_as_fractions" data-setting-key="recipe_ingredient_display_as_fractions"> {{ $__t('Display as fractions.') }}
+				</label>
+			</div>
+		</div>
+
 		<a href="{{ $U('/recipes') }}" class="btn btn-success">{{ $__t('OK') }}</a>
 	</div>
 </div>


### PR DESCRIPTION
I was just playing around with a few of these functions found from https://stackoverflow.com/questions/59727517/how-to-convert-between-decimals-and-fractions-in-php

It did require me to enable php-gmp on my system to work.

I then played with an example in the views/recipes.blade.php changing the selectedRecipes Ingredients recipe_amount to instead be {{ decimalToFraction($selectedRecipePosition->recipe_amount) }}

In the demo this was now displayed 
/recipes?recipe=5

![image](https://user-images.githubusercontent.com/54413450/73389799-8ca14f00-429a-11ea-814b-cb346be54096.png)
