### PR TITLE
Use full width for compact shopping list

### DIFF
--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -51,7 +51,6 @@ a.discrete-link:focus {
 
 .fullscreen {
 	z-index: 8888;
-	width: 100%;
 	height: 100%;
 	position: fixed;
 	top: 0;

--- a/public/viewjs/shoppinglist.js
+++ b/public/viewjs/shoppinglist.js
@@ -359,7 +359,6 @@ $(".switch-view-mode-button").on('click', function(e)
 	e.preventDefault();
 
 	$("#shoppinglist-main").toggleClass("fullscreen");
-	$("#shoppinglist-main").toggleClass("px-0 mx-0");
 	$(".dataTables_scrollHeadInner").width(""); // Remove absolute width on element set by DataTables
 	$(".dataTables_scrollHeadInner table").width(""); // Remove absolute width on element set by DataTables
 	$("body").toggleClass("fullscreen-card");


### PR DESCRIPTION
I had luck with not enforcing any width, not even 100% and removed the
padding and margin overrides from the shoppinglist.js

I also tested it on a real Android device to be really sure.