### PR TITLE
Default initial recipe add for mealplan to use recipe's base_servings

### DIFF
--- a/public/viewjs/mealplan.js
+++ b/public/viewjs/mealplan.js
@@ -783,5 +783,16 @@ Grocy.Components.RecipePicker.GetPicker().on('change', function(e)
 			$("#recipe_servings").focus();
 			$("#recipe_servings").select();
 		}, 200);
+
+		Grocy.Api.Get('objects/recipes/' + recipeId,
+			function(recipe)
+			{
+				$("#recipe_servings").val(recipe.base_servings);
+			},
+			function(xhr)
+			{
+				console.error(xhr);
+			}
+		);
 	}
 });


### PR DESCRIPTION
When adding a recipe to the meal plan, I would like the servings to initialize with the base_servings of the recipe.

The new edit recipe function for the meal plan is unaffected and will initialize with the servings set for that meal plan.