### PR TITLE
Localization fix

### DIFF
--- a/localization/da/strings.po
+++ b/localization/da/strings.po
@@ -1768,7 +1768,7 @@ msgid "Edit stock entry"
 msgstr "Rediger lagerpostering"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 

--- a/localization/de/strings.po
+++ b/localization/de/strings.po
@@ -1790,7 +1790,7 @@ msgid "Edit stock entry"
 msgstr "Bestandseintrag bearbeiten"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "Der Kamerazugriff ist nur möglich, wenn dein Browser dies unterstützt und "

--- a/localization/en_GB/strings.po
+++ b/localization/en_GB/strings.po
@@ -1755,10 +1755,10 @@ msgid "Edit stock entry"
 msgstr "Edit stock entry"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 
 msgid "Keep screen on"

--- a/localization/fr/strings.po
+++ b/localization/fr/strings.po
@@ -1786,7 +1786,7 @@ msgid "Edit stock entry"
 msgstr ""
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 

--- a/localization/hu/strings.po
+++ b/localization/hu/strings.po
@@ -1714,7 +1714,7 @@ msgid "Edit stock entry"
 msgstr "Készlet bejegyzés szerkesztése"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "A kamera hozzáférés csak akkor lehetséges, ha a böngésződ által támogatott "

--- a/localization/it/strings.po
+++ b/localization/it/strings.po
@@ -1796,7 +1796,7 @@ msgid "Edit stock entry"
 msgstr "Modifica voce di dispensa"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "L'accesso alla videocamera è possibile solo se supportato e consentito dal "

--- a/localization/nl/strings.po
+++ b/localization/nl/strings.po
@@ -1796,7 +1796,7 @@ msgid "Edit stock entry"
 msgstr "Bewerk voorraad item"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "Toegang tot de camera is enkel mogelijk indien dit ondersteund en toegestaan"

--- a/localization/no/strings.po
+++ b/localization/no/strings.po
@@ -1766,7 +1766,7 @@ msgid "Edit stock entry"
 msgstr "Endre beholdningsoppføring"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "Tilgang til kamera må støttes av din nettleser og grocy må serves via en "

--- a/localization/pt_BR/strings.po
+++ b/localization/pt_BR/strings.po
@@ -1779,7 +1779,7 @@ msgid "Edit stock entry"
 msgstr "Editar item no estoque"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "Acesso a Camera só é possivel caso seja suportado e permitido pelo navegador"

--- a/localization/ru/strings.po
+++ b/localization/ru/strings.po
@@ -1796,7 +1796,7 @@ msgid "Edit stock entry"
 msgstr ""
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 

--- a/localization/sk_SK/strings.po
+++ b/localization/sk_SK/strings.po
@@ -1795,7 +1795,7 @@ msgid "Edit stock entry"
 msgstr "Upraviť zásobu"
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 "Prístup ku kamere je možný iba tam, kde to podporuje a povoľuje váš "

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1607,7 +1607,7 @@ msgstr ""
 msgid "Edit stock entry"
 msgstr ""
 
-msgid "Camera access is on only possible when supported and allowed by your browser and when grocy is served via a secure (https://) connection"
+msgid "Camera access is only possible when supported and allowed by your browser and when grocy is served via a secure (https://) connection"
 msgstr ""
 
 msgid "Keep screen on"

--- a/localization/sv_SE/strings.po
+++ b/localization/sv_SE/strings.po
@@ -1768,7 +1768,7 @@ msgid "Edit stock entry"
 msgstr ""
 
 msgid ""
-"Camera access is on only possible when supported and allowed by your browser"
+"Camera access is only possible when supported and allowed by your browser"
 " and when grocy is served via a secure (https://) connection"
 msgstr ""
 

--- a/public/viewjs/components/barcodescanner.js
+++ b/public/viewjs/components/barcodescanner.js
@@ -63,7 +63,7 @@ Grocy.Components.BarcodeScanner.StartScanning = function()
 		if (error)
 		{
 			Grocy.FrontendHelpers.ShowGenericError("Error while initializing the barcode scanning library", error.message);
-			toastr.info(__t("Camera access is on only possible when supported and allowed by your browser and when grocy is served via a secure (https://) connection"));
+			toastr.info(__t("Camera access is only possible when supported and allowed by your browser and when grocy is served via a secure (https://) connection"));
 			setTimeout(function()
 			{
 				bootbox.hideAll();


### PR DESCRIPTION
I noticed a typo in an error message in the English localization when trying to scan a barcode. Looks like brainfart kinda thing, if not not feel free to ignore this PR :)

Change string 'Camera access is on only possible [..]' to 'Camera access is only possible [..]'

Cheers,