### PR TITLE
Added chore name when getting list of all chores.

### DIFF
--- a/services/ChoresService.php
+++ b/services/ChoresService.php
@@ -25,7 +25,7 @@ class ChoresService extends BaseService
 
 	public function GetCurrent()
 	{
-		$sql = 'SELECT * from chores_current';
+		$sql = 'SELECT chores_current.*, chores.name from chores_current join chores on chores_current.chore_id = chores.id';
 		return $this->getDatabaseService()->ExecuteDbQuery($sql)->fetchAll(\PDO::FETCH_OBJ);
 	}
 


### PR DESCRIPTION
When hitting the API to get a list of all chores, the response does not include the chore name.

I didn't want to then have to iterate through each one to get the name after getting the list of the chores as it could be significantly computationally expensive.

This PR just adds a join on the chores table to include the name of the chore when the list is retrieved.