### PR TITLE
629 Make ellipsis menu in stock overview more responsive

### DIFF
--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -225,6 +225,40 @@ input::-webkit-inner-spin-button {
 	display: none;
 }
 
+/* Stock overview table */
+
+.table-inline-menu.dropdown-menu {
+	padding-left: 12px;
+	padding-right: 12px;
+	width: 96vw; /* Set width of popup menu to screen size */
+}
+
+/* Set width of popup menu to fixed value on larger devices */
+@media (min-width: 400px) {
+	.table-inline-menu.dropdown-menu {
+		width: 400px;
+	}
+}
+
+.table-inline-menu .dropdown-item {
+	width: auto;
+	text-indent: -24px;
+}
+
+.table-inline-menu .dropdown-item .dropdown-item-icon {
+	min-width: 24px;
+	padding-left:20px;
+	text-align: center;
+	display: inline;
+}
+
+.table-inline-menu .dropdown-item .dropdown-item-text {
+	display: inline;
+	padding: 0;
+	word-wrap: break-word;
+	white-space: pre-wrap;
+}
+
 /* Third party component customizations - Bootstrap */
 
 /* Hide the form validation feedback icons introduced in Bootstrap 4.2.0 - a colored border is enough */

--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -233,6 +233,7 @@ input::-webkit-inner-spin-button {
 	width: 96vw; /* Set width of popup menu to screen size */
 }
 
+
 /* Set width of popup menu to fixed value on larger devices */
 @media (min-width: 400px) {
 	.table-inline-menu.dropdown-menu {
@@ -257,6 +258,7 @@ input::-webkit-inner-spin-button {
 	padding: 0;
 	word-wrap: break-word;
 	white-space: pre-wrap;
+	color: inherit;
 }
 
 /* Third party component customizations - Bootstrap */

--- a/views/batteriesoverview.blade.php
+++ b/views/batteriesoverview.blade.php
@@ -66,15 +66,15 @@
 							<button class="btn btn-sm btn-light text-secondary" type="button" data-toggle="dropdown">
 								<i class="fas fa-ellipsis-v"></i>
 							</button>
-							<div class="dropdown-menu">
+							<div class="table-inline-menu dropdown-menu dropdown-menu-right">
 								<a class="dropdown-item battery-name-cell" data-battery-id="{{ $currentBatteryEntry->battery_id }}" type="button" href="#">
-									<i class="fas fa-info"></i> {{ $__t('Show battery details') }}
+									<span class="dropdown-item-icon"><i class="fas fa-info"></i></span> <span class="dropdown-item-text">{{ $__t('Show battery details') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/batteriesjournal?battery=') }}{{ $currentBatteryEntry->battery_id }}">
-									<i class="fas fa-file-alt"></i> {{ $__t('Journal for this battery') }}
+									<span class="dropdown-item-icon"><i class="fas fa-file-alt"></i></span> <span class="dropdown-item-text">{{ $__t('Journal for this battery') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/battery/') }}{{ $currentBatteryEntry->battery_id }}">
-									<i class="fas fa-edit"></i> {{ $__t('Edit battery') }}
+									<span class="dropdown-item-icon"><i class="fas fa-edit"></i></span> <span class="dropdown-item-text">{{ $__t('Edit battery') }}</span>
 								</a>
 							</div>
 						</div>

--- a/views/choresoverview.blade.php
+++ b/views/choresoverview.blade.php
@@ -86,15 +86,15 @@
 							<button class="btn btn-sm btn-light text-secondary" type="button" data-toggle="dropdown">
 								<i class="fas fa-ellipsis-v"></i>
 							</button>
-							<div class="dropdown-menu">
+							<div class="table-inline-menu dropdown-menu dropdown-menu-right">
 								<a class="dropdown-item chore-name-cell" data-chore-id="{{ $curentChoreEntry->chore_id }}" type="button" href="#">
-									<i class="fas fa-info"></i> {{ $__t('Show chore details') }}
+									<span class="dropdown-item-icon"><i class="fas fa-info"></i></span> <span class="dropdown-item-text">{{ $__t('Show chore details') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/choresjournal?chore=') }}{{ $curentChoreEntry->chore_id }}">
-									<i class="fas fa-file-alt"></i> {{ $__t('Journal for this chore') }}
+									<span class="dropdown-item-icon"><i class="fas fa-file-alt"></i></span> <span class="dropdown-item-text">{{ $__t('Journal for this chore') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/chore/') }}{{ $curentChoreEntry->chore_id }}">
-									<i class="fas fa-edit"></i> {{ $__t('Edit chore') }}
+									<span class="dropdown-item-icon"><i class="fas fa-edit"></i></span> <span class="dropdown-item-text">{{ $__t('Edit chore') }}</span>
 								</a>
 							</div>
 						</div>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -105,7 +105,7 @@
 							data-consume-amount="1">
 							<i class="fas fa-utensils"></i> 1
 						</a>
-						<a id="product-{{ $currentStockEntry->product_id }}-consume-all-button" class="btn btn-danger btn-sm product-consume-button @if($currentStockEntry->amount == 0) disabled @endif" href="#" data-toggle="tooltip" data-placement="right" title="{{ $__t('Consume all %s which are currently in stock', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name) }}"
+						<a id="product-{{ $currentStockEntry->product_id }}-consume-all-button" class="d-none d-sm-inline-block btn btn-danger btn-sm product-consume-button @if($currentStockEntry->amount == 0) disabled @endif" href="#" data-toggle="tooltip" data-placement="right" title="{{ $__t('Consume all %s which are currently in stock', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name) }}"
 							data-product-id="{{ $currentStockEntry->product_id }}"
 							data-product-name="{{ FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name }}"
 							data-product-qu-name="{{ FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->qu_id_stock)->name }}"
@@ -125,6 +125,13 @@
 								<i class="fas fa-ellipsis-v"></i>
 							</button>
 							<div class="table-inline-menu dropdown-menu dropdown-menu-right">
+								<a id="product-{{ $currentStockEntry->product_id }}-consume-all-button" class="d-inline-block d-sm-none dropdown-item show-as-dialog-link text-danger product-consume-button @if($currentStockEntry->amount == 0) disabled @endif" href="#" data-toggle="tooltip" data-placement="right"
+									data-product-id="{{ $currentStockEntry->product_id }}"
+									data-product-name="{{ FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name }}"
+									data-product-qu-name="{{ FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->qu_id_stock)->name }}"
+									data-consume-amount="{{ $currentStockEntry->amount }}">
+									<span class="dropdown-item-icon"><i class="fas fa-utensils"></i></span> <span class="dropdown-item-text">{{ $__t('Consume all %s which are currently in stock', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name) }}</span>
+								</a>
 								<a class="dropdown-item show-as-dialog-link" type="button" href="{{ $U('/shoppinglistitem/new?embedded&updateexistingproduct&product=' . $currentStockEntry->product_id ) }}">
 									<span class="dropdown-item-icon"><i class="fas fa-shopping-cart"></i></span> <span class="dropdown-item-text">{{ $__t('Add to shopping list') }}</span>
 								</a>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -124,38 +124,38 @@
 							<button class="btn btn-sm btn-light text-secondary" type="button" data-toggle="dropdown">
 								<i class="fas fa-ellipsis-v"></i>
 							</button>
-							<div class="dropdown-menu">
+							<div class="table-inline-menu dropdown-menu dropdown-menu-right">
 								<a class="dropdown-item show-as-dialog-link" type="button" href="{{ $U('/shoppinglistitem/new?embedded&updateexistingproduct&product=' . $currentStockEntry->product_id ) }}">
-									<i class="fas fa-shopping-cart"></i> {{ $__t('Add to shopping list') }}
+									<span class="dropdown-item-icon"><i class="fas fa-shopping-cart"></i></span> <span class="dropdown-item-text">{{ $__t('Add to shopping list') }}</span>
 								</a>
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item show-as-dialog-link" type="button" href="{{ $U('/purchase?embedded&product=' . $currentStockEntry->product_id ) }}">
-									<i class="fas fa-shopping-cart"></i> {{ $__t('Purchase') }}
+									<span class="dropdown-item-icon"><i class="fas fa-shopping-cart"></i></span> <span class="dropdown-item-text">{{ $__t('Purchase') }}</span>
 								</a>
 								<a class="dropdown-item show-as-dialog-link" type="button" href="{{ $U('/consume?embedded&product=' . $currentStockEntry->product_id ) }}">
-									<i class="fas fa-utensils"></i> {{ $__t('Consume') }}
+									<span class="dropdown-item-icon"><i class="fas fa-utensils"></i></span> <span class="dropdown-item-text">{{ $__t('Consume') }}</span>
 								</a>
 								@if(GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING)
 								<a class="dropdown-item show-as-dialog-link @if($currentStockEntry->amount < 1) disabled @endif" type="button" href="{{ $U('/transfer?embedded&product=' . $currentStockEntry->product_id) }}">
-									<i class="fas fa-exchange-alt"></i> {{ $__t('Transfer') }}
+									<span class="dropdown-item-icon"><i class="fas fa-exchange-alt"></i></span> <span class="dropdown-item-text">{{ $__t('Transfer') }}</span>
 								</a>
 								@endif
 								<a class="dropdown-item show-as-dialog-link" type="button" href="{{ $U('/inventory?embedded&product=' . $currentStockEntry->product_id ) }}">
-									<i class="fas fa-list"></i> {{ $__t('Inventory') }}
+									<span class="dropdown-item-icon"><i class="fas fa-list"></i></span> <span class="dropdown-item-text">{{ $__t('Inventory') }}</span>
 								</a>
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item product-name-cell" data-product-id="{{ $currentStockEntry->product_id }}" type="button" href="#">
-									<i class="fas fa-info"></i> {{ $__t('Show product details') }}
+									<span class="dropdown-item-icon"><i class="fas fa-info"></i></span> <span class="dropdown-item-text">{{ $__t('Show product details') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/stockentries?product=') }}{{ $currentStockEntry->product_id }}"
 									data-product-id="{{ $currentStockEntry->product_id }}">
-									<i class="fas fa-boxes"></i> {{ $__t('Show stock entries') }}
+									<span class="dropdown-item-icon"><i class="fas fa-boxes"></i></span> <span class="dropdown-item-text">{{ $__t('Show stock entries') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/stockjournal?product=') }}{{ $currentStockEntry->product_id }}">
-									<i class="fas fa-file-alt"></i> {{ $__t('Stock journal for this product') }}
+									<span class="dropdown-item-icon"><i class="fas fa-file-alt"></i></span> <span class="dropdown-item-text">{{ $__t('Stock journal for this product') }}</span>
 								</a>
 								<a class="dropdown-item" type="button" href="{{ $U('/product/') }}{{ $currentStockEntry->product_id . '?returnto=%2Fstockoverview' }}">
-									<i class="fas fa-edit"></i> {{ $__t('Edit product') }}
+									<span class="dropdown-item-icon"><i class="fas fa-edit"></i></span> <span class="dropdown-item-text">{{ $__t('Edit product') }}</span>
 								</a>
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item product-consume-button product-consume-button-spoiled @if($currentStockEntry->amount < 1) disabled @endif" type="button" href="#"
@@ -163,11 +163,11 @@
 									data-product-name="{{ FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name }}"
 									data-product-qu-name="{{ FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->qu_id_stock)->name }}"
 									data-consume-amount="1">
-									<i class="fas fa-utensils"></i> {{ $__t('Consume %1$s of %2$s as spoiled', '1 ' . FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->qu_id_stock)->name, FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name) }}
+									<span class="dropdown-item-icon"><i class="fas fa-utensils"></i></span> <span class="dropdown-item-text">{{ $__t('Consume %1$s of %2$s as spoiled', '1 ' . FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->qu_id_stock)->name, FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name) }}</span>
 								</a>
 								@if(GROCY_FEATURE_FLAG_RECIPES)
 								<a class="dropdown-item" type="button" href="{{ $U('/recipes?search=') }}{{ FindObjectInArrayByPropertyValue($products, 'id', $currentStockEntry->product_id)->name }}">
-									<i class="fas fa-cocktail"></i> {{ $__t('Search for recipes containing this product') }}
+									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Search for recipes containing this product') }}</span>
 								</a>
 								@endif
 							</div>


### PR DESCRIPTION
Closes #629 by moving the `consume all` button to the ellipsis menu on small devices.
The display of the ellipsis menu on small devices is more responsive as well.