### PR TITLE
Check if all dependencies are installed

### DIFF
--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -1,0 +1,38 @@
+<?php
+
+class ERequirementNotMet extends Exception {
+}
+
+class PrerequisiteChecker {
+    
+    public function checkRequirements() {
+        self::checkForConfigFile();
+        self::checkForConfigDistFile();
+        self::checkForComposer();
+        self::checkForYarn();
+    }
+    
+    
+    private function checkForConfigFile() {
+        if (!file_exists(__DIR__ . "/../data/config.php"))
+            throw new ERequirementNotMet("/data/config.php not found. Have you copied config-dist.php to the data directory and renamed it to config.php?");
+    }
+
+    private function checkForConfigDistFile() {
+        if (!file_exists(__DIR__ . "/../config-dist.php"))
+            throw new ERequirementNotMet("config-dist.php not found. Please do not remove this file.");
+    }
+
+    private function checkForComposer() {
+        if (!file_exists(__DIR__ . "/../vendor/autoload.php"))
+            throw new ERequirementNotMet("/vendor/autoload.php not found. Have you run Composer?");
+    }
+
+    private function checkForYarn() {
+        if (!file_exists(__DIR__ . "/../public/node_modules"))
+            throw new ERequirementNotMet("/public/node_modules not found. Have you run Yarn?");
+    }
+}
+
+
+?>

--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -3,13 +3,17 @@
 class ERequirementNotMet extends Exception {
 }
 
+
+const REQUIRED_PHP_EXTENSIONS = array("fileinfo", "pdo_sqlite", "gd");
+
 class PrerequisiteChecker {
     
     public function checkRequirements() {
-        self::checkForConfigFile();
+       /* self::checkForConfigFile();
         self::checkForConfigDistFile();
         self::checkForComposer();
-        self::checkForYarn();
+        self::checkForYarn(); */
+        self::checkForPhpExtensions();
     }
     
     
@@ -31,6 +35,14 @@ class PrerequisiteChecker {
     private function checkForYarn() {
         if (!file_exists(__DIR__ . "/../public/node_modules"))
             throw new ERequirementNotMet("/public/node_modules not found. Have you run Yarn?");
+    }
+
+    private function checkForPhpExtensions() {
+        $loadedExtensions = get_loaded_extensions();
+        foreach (REQUIRED_PHP_EXTENSIONS as $extension) {
+            if (!in_array($extension, $loadedExtensions))
+                throw new ERequirementNotMet("PHP module '{$extension}' not installed, but required.");
+        }
     }
 }
 

--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -9,10 +9,10 @@ const REQUIRED_PHP_EXTENSIONS = array("fileinfo", "pdo_sqlite", "gd");
 class PrerequisiteChecker {
     
     public function checkRequirements() {
-       /* self::checkForConfigFile();
+        self::checkForConfigFile();
         self::checkForConfigDistFile();
         self::checkForComposer();
-        self::checkForYarn(); */
+        self::checkForYarn();
         self::checkForPhpExtensions();
     }
     

--- a/public/index.php
+++ b/public/index.php
@@ -1,3 +1,13 @@
 <?php
 
+require_once __DIR__ . '/../helpers/PrerequisiteChecker.php';
+
+try {
+	(new PrerequisiteChecker)->checkRequirements();
+} catch (ERequirementNotMet $e) {
+    die("Unable to run grocy: " . $e->getMessage());
+}
+
 require_once __DIR__ . '/../app.php';
+
+?>


### PR DESCRIPTION
A lot of people had problems with installing grocy, as it only displays an empty page if there is an error.  This little helper does a quick and cheap check if all dependencies are installed and config.php / config-dist.php exists.

If something is missing, the script stops and outputs an error.