### PR TITLE
Simplify release asset naming

### DIFF
--- a/.devtools/create_release_package.bat
+++ b/.devtools/create_release_package.bat
@@ -5,12 +5,8 @@ set projectPath=%projectPath%\..
 set releasePath=%projectPath%\.release
 mkdir "%releasePath%"
 
-copy "%projectPath%\version.json" versiontemp.json
-for /f "tokens=*" %%a in ('jq .Version versiontemp.json --raw-output') do set version=%%a
-del versiontemp.json
-
-del "%releasePath%\grocy_%version%.zip"
-7za a -r "%releasePath%\grocy_%version%.zip" "%projectPath%\*" -xr!.* -xr!build.bat -xr!composer.json -xr!composer.lock -xr!package.json -xr!yarn.lock -xr!publication_assets
-7za a "%releasePath%\grocy_%version%.zip" "%projectPath%\public\.htaccess"
-7za rn "%releasePath%\grocy_%version%.zip" .htaccess public\.htaccess
-7za d "%releasePath%\grocy_%version%.zip" data\*.* data\storage data\viewcache\*
+del "%releasePath%\grocy.zip"
+7za a -r "%releasePath%\grocy.zip" "%projectPath%\*" -xr!.* -xr!build.bat -xr!composer.json -xr!composer.lock -xr!package.json -xr!yarn.lock -xr!publication_assets
+7za a "%releasePath%\grocy.zip" "%projectPath%\public\.htaccess"
+7za rn "%releasePath%\grocy.zip" .htaccess public\.htaccess
+7za d "%releasePath%\grocy.zip" data\*.* data\storage data\viewcache\*

--- a/.devtools/create_release_package.bat
+++ b/.devtools/create_release_package.bat
@@ -5,6 +5,14 @@ set projectPath=%projectPath%\..
 set releasePath=%projectPath%\.release
 mkdir "%releasePath%"
 
+del "%releasePath%\grocy.tar"
+del "%releasePath%\grocy.tar.gz"
+7za a -r "%releasePath%\grocy.tar" "%projectPath%\*" -xr!.* -xr!package.json -xr!publication_assets
+7za a "%releasePath%\grocy.tar" "%projectPath%\public\.htaccess"
+7za rn "%releasePath%\grocy.tar" .htaccess public\.htaccess
+7za d "%releasePath%\grocy.tar" data\*.* data\storage data\viewcache\*
+7za a "%releasePath%\grocy.tar.gz" "%releasePath%\grocy.tar"
+
 del "%releasePath%\grocy.zip"
 7za a -r "%releasePath%\grocy.zip" "%projectPath%\*" -xr!.* -xr!build.bat -xr!composer.json -xr!composer.lock -xr!package.json -xr!yarn.lock -xr!publication_assets
 7za a "%releasePath%\grocy.zip" "%projectPath%\public\.htaccess"

--- a/.devtools/create_release_package.bat
+++ b/.devtools/create_release_package.bat
@@ -7,7 +7,7 @@ mkdir "%releasePath%"
 
 del "%releasePath%\grocy.tar"
 del "%releasePath%\grocy.tar.gz"
-7za a -r "%releasePath%\grocy.tar" "%projectPath%\*" -xr!.* -xr!package.json -xr!publication_assets
+7za a -r "%releasePath%\grocy.tar" "%projectPath%\*" -xr!.* -xr!publication_assets
 7za a "%releasePath%\grocy.tar" "%projectPath%\public\.htaccess"
 7za rn "%releasePath%\grocy.tar" .htaccess public\.htaccess
 7za d "%releasePath%\grocy.tar" data\*.* data\storage data\viewcache\*


### PR DESCRIPTION
This is an attempt at providing static asset filenames for release purposes.  I've approximated testing of the `7za` commands locally, but am using a Linux-based environment so cannot currently guarantee that these function correctly under a Windows environment.

Resolves #640 