### PR TITLE
Return amount of stock in location API request

### DIFF
--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -3547,6 +3547,9 @@
 					"product_id": {
 						"type": "integer"
 					},
+					"amount": {
+						"type": "integer"
+					},
 					"location_id": {
 						"type": "integer"
 					},
@@ -3560,6 +3563,7 @@
 				"example": {
 					"id": "1",
 					"product_id": "3",
+					"amount": "2",
 					"location_id": "1",
 					"name": "Fridge"
 				}

--- a/migrations/0099.sql
+++ b/migrations/0099.sql
@@ -10,3 +10,18 @@ ADD shopping_location_id INTEGER;
 
 ALTER TABLE stock
 ADD shopping_location_id INTEGER;
+
+DROP VIEW stock_current_locations;
+CREATE VIEW stock_current_locations
+AS
+SELECT
+	1 AS id, -- Dummy, LessQL needs an id column
+	s.product_id,
+        SUM(s.amount) as amount,
+	s.location_id AS location_id,
+	l.name AS location_name,
+	l.is_freezer AS location_is_freezer
+FROM stock s
+JOIN locations l
+	ON s.location_id = l.id
+GROUP BY s.product_id, s.location_id, l.name;


### PR DESCRIPTION
For the `/stock/products/{productId}/locations` request, the amount of stock for each location is returned as well

I added it to the already existing 99.sql - is that the correct way or would it be better to use a 100.sql? The 99.sql is not in the current release.