### PR TITLE
Preset the stock qu with the purchase qu on new products.

### DIFF
--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -423,3 +423,13 @@ $("#qu-conversion-add-button").on("click", function(e)
 	Grocy.ProductEditFormRedirectUri = U("/quantityunitconversion/new?product=editobjectid");
 	$('#save-product-button').click();
 });
+
+$('#qu_id_purchase').blur(function(e) 
+{
+	// Preset the stock quantity unit with the purchase quantity unit, if the stock quantity unit is unset.
+	var QuIdStock = $('#qu_id_stock');
+	var QuIdPurchase = $('#qu_id_purchase');
+	if (QuIdStock[0].selectedIndex === 0 && QuIdPurchase[0].selectedIndex !== 0) {
+		QuIdStock[0].selectedIndex = QuIdPurchase[0].selectedIndex;
+	}
+});


### PR DESCRIPTION
Preset the stock quantity unit with the purchase quantity unit, if the stock quantity unit is unset.

The quantity units are the same in the most cases. So this enhances the input of new products a little bit.