### PR TITLE
Add ability to import json data from Kroger grocery stores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
 		"files": [
 			"helpers/extensions.php"
 		]
+	},
+	"require-dev": {
+		"phpunit/phpunit": "9"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c7420e77a3f1afb59e00560d5b9081c",
+    "content-hash": "087239c88ff18285970bf9079e165232",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2470,7 +2470,1603 @@
             "time": "2019-08-07T07:10:58+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2018-08-07T13:53:10+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-22T12:28:44+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.3",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-token-stream": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^2.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/version": "^3.0",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-02-19T13:41:19+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2020-02-07T06:05:22+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-02-07T06:06:11+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2020-02-01T07:43:44+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2020-02-07T06:08:11+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2020-02-07T06:19:00+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "a5be9621b19ee19dca5f150a5b159f48b5389547"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a5be9621b19ee19dca5f150a5b159f48b5389547",
+                "reference": "a5be9621b19ee19dca5f150a5b159f48b5389547",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.3",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^8.0",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-invoker": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-timer": "^3.0",
+                "sebastian/comparator": "^4.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/exporter": "^4.0",
+                "sebastian/global-state": "^4.0",
+                "sebastian/object-enumerator": "^4.0",
+                "sebastian/resource-operations": "^3.0",
+                "sebastian/type": "^2.0",
+                "sebastian/version": "^3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-02-07T06:56:17+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2020-02-07T06:20:13+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2020-02-07T06:08:51+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2020-02-07T06:09:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2020-02-19T13:40:20+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2020-02-07T06:10:52+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2020-02-07T06:11:37+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67516b175550abad905dc952f43285957ef4363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
+                "reference": "e67516b175550abad905dc952f43285957ef4363",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2020-02-07T06:12:23+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-02-07T06:19:40+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-02-07T06:18:20+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2020-02-07T06:13:02+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2020-02-07T06:13:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2020-01-21T06:36:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2020-02-14T12:15:55+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
@@ -2479,5 +4075,6 @@
     "platform": {
         "php": ">=7.2"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/config-dist.php
+++ b/config-dist.php
@@ -139,6 +139,7 @@ Setting('FEATURE_FLAG_TASKS', true);
 Setting('FEATURE_FLAG_BATTERIES', true);
 Setting('FEATURE_FLAG_EQUIPMENT', true);
 Setting('FEATURE_FLAG_CALENDAR', true);
+Setting('FEATURE_FLAG_UPLOAD_JSON', true);
 
 
 # Sub feature flags

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -307,15 +307,23 @@ class StockApiController extends BaseApiController
 			}
 			
 			$default_location_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_location_id');
-			$default_qu_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_qu_id');
-
 			if (!$default_location_id) 
+			{
 				$default_location_id = $this->getDatabase()->locations()->limit(1)->fetch()['id'];
-			
+			}
+
+			$default_qu_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_qu_id');
 			if (!$default_qu_id)
+			{
 				$default_qu_id = $this->getDatabase()->quantity_units()->limit(1)->fetch()['id'];
+			}
 				
-			$shopping_location_id = array_key_exists('shopping_location_id', $requestBody) ? $requestBody['shopping_location_id'] : null;
+			$shopping_location_id = null;
+			if (array_key_exists('shopping_location_id', $requestBody))
+			{
+				$shopping_location_id = $requestBody['shopping_location_id'];
+			}
+
 			$parsedData = json_decode($requestBody['json-data'], true);
 			
 			$lastInsertId = $this->getStockService()->AddMultipleProducts($parsedData, $default_qu_id, 

--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -73,23 +73,31 @@ class StockController extends BaseController
 			'locations' => $this->getDatabase()->locations()->orderBy('name')
 		]);
 	}
-	
+
 	public function UploadJson(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
 		$location_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_location_id');
 		$location = null;
 		if ($location_id > 0)
+		{
 			$location = $this->getDatabase()->locations()->where('id', $location_id).fetch();
+		}
 		else
+		{
 			$location = $this->getDatabase()->locations()->limit(1)->fetch();
-		
+		}
+
 		$qu_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_location_id');
 		$quantity_unit = null;
 		if ($qu_id > 0)
+		{
 			$quantity_unit = $this->getDatabase()->quantity_units()->where('id', $qui_id).fetch();
+		}
 		else
+		{
 			$quantity_unit = $this->getDatabase()->quantity_units()->limit(1)->fetch();
-
+		}
+		
 		return $this->renderPage($response, 'uploadjson', [
 			'location' => $location,
 			'quantityunit' => $quantity_unit,

--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -73,6 +73,29 @@ class StockController extends BaseController
 			'locations' => $this->getDatabase()->locations()->orderBy('name')
 		]);
 	}
+	
+	public function UploadJson(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		$location_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_location_id');
+		$location = null;
+		if ($location_id > 0)
+			$location = $this->getDatabase()->locations()->where('id', $location_id).fetch();
+		else
+			$location = $this->getDatabase()->locations()->limit(1)->fetch();
+		
+		$qu_id = $this->getUsersService()->GetUserSetting(GROCY_USER_ID, 'product_presets_location_id');
+		$quantity_unit = null;
+		if ($qu_id > 0)
+			$quantity_unit = $this->getDatabase()->quantity_units()->where('id', $qui_id).fetch();
+		else
+			$quantity_unit = $this->getDatabase()->quantity_units()->limit(1)->fetch();
+
+		return $this->renderPage($response, 'uploadjson', [
+			'location' => $location,
+			'quantityunit' => $quantity_unit,
+			'shoppinglocations' => $this->getDatabase()->shopping_locations()->orderBy('name')
+		]);
+	}
 
 	public function Inventory(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{

--- a/helpers/KrogerToGrocyConverter.php
+++ b/helpers/KrogerToGrocyConverter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Grocy\Helpers;
+
+use Grocy\Services\StockService;
+
+class KrogerToGrocyConverter
+{
+	// Fields returned: 'name', 'location_id', 'qu_id_purchase', 'qu_id_stock',
+	// 'qu_factor_purchase_to_stock', 'barcode', 'default_best_before_days'
+	// 'quantity', 'transaction_date', 'price_paid'
+	public static function ConvertJson($data, $default_quantity_units, $default_location_id) 
+	{
+		if (array_key_exists("data", $data))
+		{
+			$data = $data['data'];
+		}
+		
+		$products = array();
+		foreach ($data as &$receipt) 
+		{
+			if (!array_key_exists("items", $receipt))
+			{
+				continue;
+			}
+
+			$dateArray = date_parse($receipt['transactionTime']) ?: getdate();
+			$transactionDate = sprintf("%04d-%02d-%02d", $dateArray["year"], $dateArray["month"], $dateArray["day"]);
+			foreach ($receipt['items'] as &$item)
+			{
+				if (!array_key_exists("detail", $item))
+				{
+					continue;
+				}
+
+				$product = null;
+				$barcode = KrogerToGrocyConverter::ConvertUpcToBarcode($item["baseUpc"]);
+
+				$product = array(
+					'name' => $item["detail"]["description"],
+					'location_id' => $default_location_id,
+					'qu_id_purchase' => $default_quantity_units,
+					'qu_id_stock' => $default_quantity_units,
+					'qu_factor_purchase_to_stock' => 1,
+					'barcode' => $barcode,
+					'default_best_before_days' => 21,
+					'quantity' => $item['quantity'],
+					'transaction_date' => $transactionDate,
+					'price_paid' => $item['pricePaid']
+				);
+
+				array_push($products, $product);
+			}
+		}
+		return $products;
+	}
+	
+	// Anatomy of a barcode: 0		07222526014		 2
+	//						 ^			 ^			 ^
+	//				   country code		upc	 computed check digit
+	public static function ConvertUpcToBarcode($upc)
+	{
+		$upclen = strlen($upc);
+		if ($upclen < 11 && intval($upc) > 0) 
+		{
+			throw new \Exception('UPC code should be at least 11 digits');
+		}
+
+		$countryCode = $upclen > 11 ? $upc[$upclen - 12] : 0 /*US/Canda*/;
+		$upc = substr($upc, $upclen - 11);
+
+		$checkSum = (intval($upc[0]) + intval($upc[2]) + intval($upc[4]) + intval($upc[6]) + intval($upc[8]) + $upc[10]) * 3;
+		$checkSum = $checkSum + intval($upc[1]) + intval($upc[3]) + intval($upc[5]) + intval($upc[7]) + intval($upc[9]);
+		
+		$checkDigit = 10 - ($checkSum % 10);
+		
+		return $countryCode . $upc . strval($checkDigit);
+	}
+}
+
+?>

--- a/helpers/KrogerToGrocyConverter.php
+++ b/helpers/KrogerToGrocyConverter.php
@@ -2,8 +2,6 @@
 
 namespace Grocy\Helpers;
 
-use Grocy\Services\StockService;
-
 class KrogerToGrocyConverter
 {
 	// Fields returned: 'name', 'location_id', 'qu_id_purchase', 'qu_id_stock',

--- a/helpers/KrogerToGrocyConverter.php
+++ b/helpers/KrogerToGrocyConverter.php
@@ -6,10 +6,10 @@ class KrogerToGrocyConverter
 {
 	// Fields returned: 'name', 'location_id', 'qu_id_purchase', 'qu_id_stock',
 	// 'qu_factor_purchase_to_stock', 'barcode', 'default_best_before_days'
-	// 'quantity', 'transaction_date', 'price_paid', 'picture_url'
+	// 'quantity', 'transaction_date', 'price_paid', 'picture_url', 'min_stock_amount'
 	public static function ConvertJson($data, $default_quantity_units, $default_location_id) 
 	{
-		if (array_key_exists("data", $data))
+		if ($data != null && array_key_exists("data", $data))
 		{
 			$data = $data['data'];
 		}

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1760,14 +1760,66 @@ msgstr ""
 msgid "Group ingredients by their product group"
 msgstr ""
 
-msgid "Unknown store"
+msgid "Upload json"
+msgstr ""
+
+msgid "Upload Json"
+msgstr ""
+
+msgid "Upload Purchase Data As JSON"
+msgstr ""
+
+msgid "Error while saving, probably an error in the json"
+msgstr ""
+
+msgid "Default Quantity unit purchase"
+msgstr ""
+
+msgid "Don't add old purchases to stock"
+msgstr ""
+
+msgid "JSON Data"
+msgstr ""
+
+msgid ""
+"Kroger grocery stores allow manual access to past purchases in json form \r\n"
+"\t\t\tthrough a browser's developer tools."
+msgstr ""
+
+msgid ""
+"To get this json, open developer tools\r\n"
+"\t\t\tand navigate to https://www.qfc.com/mypurchases (or another Kroger grocer,\r\n"
+"\t\t\tsuch as https://www.fredmeyer.com/mypurchases) and look for a call to \r\n"
+"\t\t\t/mypurchases/api/v1/receipt/details.  The response will contain data for the\r\n"
+"\t\t\tlast five receipts."
 msgstr ""
 
 msgid "Store"
 msgstr ""
 
+msgid "Default shopping location"
+msgstr ""
+
 msgid "Transaction successfully undone"
 msgstr ""
 
+msgid "Unknown store"
+msgstr ""
+
 msgid "Default store"
+msgstr ""
+
+msgid "Default location "
+msgstr ""
+
+msgid "Change this value in user settings"
+msgstr ""
+
+msgid "Default Quantity unit "
+msgstr ""
+
+msgid "Don't add to stock"
+msgstr ""
+
+msgid ""
 msgstr ""

--- a/migrations/0099.sql
+++ b/migrations/0099.sql
@@ -1,0 +1,2 @@
+ALTER TABLE products
+ADD picture_url TEXT;

--- a/public/viewjs/components/productcard.js
+++ b/public/viewjs/components/productcard.js
@@ -92,6 +92,11 @@ Grocy.Components.ProductCard.Refresh = function(productId)
 				$("#productcard-product-picture").removeClass("d-none");
 				$("#productcard-product-picture").attr("src", U('/api/files/productpictures/' + btoa(productDetails.product.picture_file_name) + '?force_serve_as=picture&best_fit_width=400'));
 			}
+			else if (productDetails.product.picture_url !== null && !productDetails.product.picture_url.isEmpty())
+			{
+				$("#productcard-product-picture").removeClass("d-none");
+				$("#productcard-product-picture").attr("src", productDetails.product.picture_url);
+			}
 			else
 			{
 				$("#productcard-product-picture").addClass("d-none");

--- a/public/viewjs/mealplan.js
+++ b/public/viewjs/mealplan.js
@@ -226,9 +226,19 @@ var calendar = $("#calendar").fullCalendar({
 					</h5> \
 				</div>');
 
+			var pictureUrl = null;
 			if (productDetails.product.picture_file_name && !productDetails.product.picture_file_name.isEmpty())
 			{
-				element.html(element.html() + '<div class="mx-auto"><img data-src="' + U("/api/files/productpictures/") + btoa(productDetails.product.picture_file_name) + '?force_serve_as=picture&best_fit_width=400" class="img-fluid lazy"></div>')
+				pictureUrl = U("/api/files/productpictures/") + btoa(productDetails.product.picture_file_name) + '?force_serve_as=picture&best_fit_width=400';
+			}
+			else if (productDetails.product.picture_url && !productDetails.product.picture_url.isEmpty())
+			{
+				pictureUrl = productDetails.product.picture_url;
+			}
+
+			if (pictureUrl)
+			{
+				element.html(element.html() + '<div class="mx-auto"><img data-src="' + pictureUrl + '" class="img-fluid lazy"></div>')
 			}
 
 			var dayRecipeName = event.start.format("YYYY-MM-DD");

--- a/public/viewjs/uploadjson.js
+++ b/public/viewjs/uploadjson.js
@@ -1,0 +1,27 @@
+$('#upload-json-button').on('click', function(e)
+{
+	e.preventDefault();
+
+	var redirectDestination = U('/stockoverview');
+	var returnTo = GetUriParam('returnto');
+	if (returnTo !== undefined)
+	{
+		redirectDestination = U(returnTo);
+	}
+
+	var jsonData = $('#json-form').serializeJSON({ checkboxUncheckedValue: "0" });
+
+	Grocy.FrontendHelpers.BeginUiBusy("json-form");
+
+    Grocy.Api.Post('uploadjson', jsonData,
+        function(result)
+        {
+            window.location.href = redirectDestination
+        },
+        function (xhr)
+        {
+            Grocy.FrontendHelpers.EndUiBusy("json-form");
+            Grocy.FrontendHelpers.ShowGenericError('Error while saving, probably an error in the json', xhr.response)
+        }
+    );
+});

--- a/routes.php
+++ b/routes.php
@@ -128,6 +128,12 @@ $app->group('', function(RouteCollectorProxy $group)
 		$group->get('/calendar', '\Grocy\Controllers\CalendarController:Overview');
 	}
 
+	// Upload json routes
+	if (GROCY_FEATURE_FLAG_UPLOAD_JSON)
+	{
+		$group->get('/uploadjson', '\Grocy\Controllers\StockController:UploadJson');
+	}
+
 	// OpenAPI routes
 	$group->get('/api', '\Grocy\Controllers\OpenApiController:DocumentationUi');
 	$group->get('/manageapikeys', '\Grocy\Controllers\OpenApiController:ApiKeysList');
@@ -248,6 +254,12 @@ $app->group('/api', function(RouteCollectorProxy $group)
 	{
 		$group->get('/calendar/ical', '\Grocy\Controllers\CalendarApiController:Ical')->setName('calendar-ical');
 		$group->get('/calendar/ical/sharing-link', '\Grocy\Controllers\CalendarApiController:IcalSharingLink');
+	}
+	
+	// Upload json routes
+	if (GROCY_FEATURE_FLAG_UPLOAD_JSON)
+	{
+		$group->post('/uploadjson', '\Grocy\Controllers\StockApiController:UploadJson');
 	}
 })->add(new CorsMiddleware([
 	'origin' => ["*"],

--- a/tests/KrogerToGrocyConverterTest.php
+++ b/tests/KrogerToGrocyConverterTest.php
@@ -17,35 +17,35 @@ final class KrogerToGrocyConverterTest extends TestCase
 		$this->assertEquals(
 			"0072220005165",
 			KrogerToGrocyConverter::ConvertUpcToBarcode("0000007222000516")
-        );
-        
-        $this->assertEquals(
-            "0000000041300",
-            KrogerToGrocyConverter::ConvertUpcToBarcode("0000000004130")
-        );
-    }
-    
-    public function testConvertJson(): void
-    {
-        $testjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts.json");
-        $default_quantity_units = 3;
-        $default_location_id = 2;
+		);
+		
+		$this->assertEquals(
+			"0000000041300",
+			KrogerToGrocyConverter::ConvertUpcToBarcode("0000000004130")
+		);
+	}
+	
+	public function testConvertJson(): void
+	{
+		$testjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts.json");
+		$default_quantity_units = 3;
+		$default_location_id = 2;
 
-        $products = KrogerToGrocyConverter::ConvertJson(json_decode($testjson, true), $default_quantity_units, $default_location_id);
+		$products = KrogerToGrocyConverter::ConvertJson(json_decode($testjson, true), $default_quantity_units, $default_location_id);
 
-        $expectedjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts_expected.json");
-        $expected = json_decode($expectedjson, true);
+		$expectedjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts_expected.json");
+		$expected = json_decode($expectedjson, true);
 
-        $this->assertEquals(count($expected), count($products));
+		$this->assertEquals(count($expected), count($products));
 
-        foreach ($expected as $index => $product)
-        {
-            foreach ($product as $key => $value)
-            {
-                $this->assertEquals($value, $products[$index][$key], "Failed matching key " . $key);
-            }
-        }
-    }
+		foreach ($expected as $index => $product)
+		{
+			foreach ($product as $key => $value)
+			{
+				$this->assertEquals($value, $products[$index][$key], "Failed matching key " . $key);
+			}
+		}
+	}
 }
 
 ?>

--- a/tests/KrogerToGrocyConverterTest.php
+++ b/tests/KrogerToGrocyConverterTest.php
@@ -17,7 +17,12 @@ final class KrogerToGrocyConverterTest extends TestCase
 		$this->assertEquals(
 			"0072220005165",
 			KrogerToGrocyConverter::ConvertUpcToBarcode("0000007222000516")
-		);
+        );
+        
+        $this->assertEquals(
+            "0000000041300",
+            KrogerToGrocyConverter::ConvertUpcToBarcode("0000000004130")
+        );
     }
     
     public function testConvertJson(): void
@@ -37,7 +42,7 @@ final class KrogerToGrocyConverterTest extends TestCase
         {
             foreach ($product as $key => $value)
             {
-                $this->assertEquals($value, $products[$index][$key]);
+                $this->assertEquals($value, $products[$index][$key], "Failed matching key " . $key);
             }
         }
     }

--- a/tests/KrogerToGrocyConverterTest.php
+++ b/tests/KrogerToGrocyConverterTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use Grocy\Helpers\KrogerToGrocyConverter;
+
+final class KrogerToGrocyConverterTest extends TestCase
+{
+	public function testConvertUpcToBarcode(): void
+	{
+		$this->assertEquals(
+			"0722252601421",
+			KrogerToGrocyConverter::ConvertUpcToBarcode("0072225260142")
+		);
+		$this->assertEquals(
+			"0072220005165",
+			KrogerToGrocyConverter::ConvertUpcToBarcode("07222000516")
+		);
+		$this->assertEquals(
+			"0072220005165",
+			KrogerToGrocyConverter::ConvertUpcToBarcode("0000007222000516")
+		);
+    }
+    
+    public function testConvertJson(): void
+    {
+        $testjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts.json");
+        $default_quantity_units = 3;
+        $default_location_id = 2;
+
+        $products = KrogerToGrocyConverter::ConvertJson(json_decode($testjson, true), $default_quantity_units, $default_location_id);
+
+        $expectedjson = file_get_contents(dirname(__FILE__) . "/testdata/receipts_expected.json");
+        $expected = json_decode($expectedjson, true);
+
+        $this->assertEquals(count($expected), count($products));
+
+        foreach ($expected as $index => $product)
+        {
+            foreach ($product as $key => $value)
+            {
+                $this->assertEquals($value, $products[$index][$key]);
+            }
+        }
+    }
+}
+
+?>

--- a/tests/testdata/receipts.json
+++ b/tests/testdata/receipts.json
@@ -1,0 +1,118 @@
+{
+	"data": [{
+			"address": {
+				"address1": "8867 161st Ave NE",
+				"address2": "Redmond, WA 98052"
+			},
+			"items": [{
+					"itemIdentifier": "0004000052550",
+					"baseUpc": "0004000052550",
+					"department": "4",
+					"unitOfMeasure": "EA",
+					"detail": {
+						"upc": "0004000052550",
+						"customerFacingSize": "9.7 oz",
+						"description": "Twix Minis Size Chocolate Cookie Bars",
+						"familyTreeCommodityCode": "202",
+						"familyTreeDepartmentCode": "04",
+						"familyTreeSubCommodityCode": "3227",
+						"mainImage": "https://www.kroger.com/product/images/small/front/0004000052550",
+						"soldInStore": true,
+						"categories": [{
+								"category": "Candy",
+								"categoryCode": "77"
+							}
+						]
+					},
+					"quantity": 1,
+					"totalSavings": 1.79,
+					"extendedPrice": 4.29,
+					"pricePaid": 2.50,
+					"priceModifiers": [{
+							"type": "1",
+							"amount": 1.79,
+							"action": "Subtract",
+							"promotionId": "10000019468",
+							"couponType": "73",
+							"reportingCode": "0"
+						}
+					],
+					"unitPrice": 4.29,
+					"itemType": "NORMAL",
+					"entryMethod": "KEYED_ITEM_CODE",
+					"imageUrl": "https://www.kroger.com/product/images/small/front/0004000052550",
+					"detailUrl": "/p/item/0004000052550",
+					"sellableUpc": "0004000052550",
+					"fuel": false,
+					"giftCard": false,
+					"managerOverrideIgnored": false,
+					"containerDeposit": false,
+					"pharmacy": false,
+					"managerOverride": false,
+					"weighted": false
+				}, {
+					"itemIdentifier": "0007222000516",
+					"baseUpc": "0007222000516",
+					"department": "75",
+					"unitOfMeasure": "EA",
+					"detail": {
+						"upc": "0007222000516",
+						"customerFacingSize": "6 ct / 13 oz",
+						"description": "Franz Extra Crisp English Muffins",
+						"familyTreeCommodityCode": "050",
+						"familyTreeDepartmentCode": "75",
+						"familyTreeSubCommodityCode": "2407",
+						"mainImage": "https://www.kroger.com/product/images/small/front/0007222000516",
+						"soldInStore": true,
+						"categories": [{
+								"category": "Breakfast",
+								"categoryCode": "10"
+							}
+						]
+					},
+					"quantity": 3,
+					"totalSavings": 6.9,
+					"extendedPrice": 12.87,
+					"pricePaid": 5.97,
+					"priceModifiers": [{
+							"type": "1",
+							"amount": 2.3,
+							"action": "Subtract",
+							"promotionId": "10000013849",
+							"couponType": "73",
+							"reportingCode": "0"
+						}, {
+							"type": "1",
+							"amount": 2.3,
+							"action": "Subtract",
+							"promotionId": "10000013849",
+							"couponType": "73",
+							"reportingCode": "0"
+						}, {
+							"type": "1",
+							"amount": 2.3,
+							"action": "Subtract",
+							"promotionId": "10000013849",
+							"couponType": "73",
+							"reportingCode": "0"
+						}
+					],
+					"unitPrice": 4.29,
+					"itemType": "NORMAL",
+					"entryMethod": "KEYED_ITEM_CODE",
+					"imageUrl": "https://www.kroger.com/product/images/small/front/0007222000516",
+					"detailUrl": "/p/item/0007222000516",
+					"sellableUpc": "0007222000516",
+					"fuel": false,
+					"giftCard": false,
+					"managerOverrideIgnored": false,
+					"containerDeposit": false,
+					"pharmacy": false,
+					"managerOverride": false,
+					"weighted": false
+				}
+			],
+			"transactionTime": "2020-03-21T09:14:00"
+		}
+	]
+}

--- a/tests/testdata/receipts.json
+++ b/tests/testdata/receipts.json
@@ -110,6 +110,45 @@
 					"pharmacy": false,
 					"managerOverride": false,
 					"weighted": false
+				},
+				{
+					"itemIdentifier": "0000000004648",
+					"baseUpc": "0000000004648",
+					"department": "57",
+					"unitOfMeasure": "LBR",
+					"detail": {
+						"upc": "0000000004648",
+						"customerFacingSize": "1 lb",
+						"description": "Mushrooms - Crimini - Bulk",
+						"familyTreeCommodityCode": "613",
+						"familyTreeDepartmentCode": "57",
+						"familyTreeSubCommodityCode": "8067",
+						"mainImage": "https://www.kroger.com/product/images/small/front/0000000004648",
+						"soldInStore": true,
+						"categories": [{
+								"category": "Produce",
+								"categoryCode": "36"
+							}
+						]
+					},
+					"quantity": 0.84,
+					"totalSavings": 0,
+					"extendedPrice": 3.35,
+					"pricePaid": 3.35,
+					"priceModifiers": [],
+					"unitPrice": 3.99,
+					"itemType": "NORMAL",
+					"entryMethod": "KEYED_ITEM_CODE",
+					"imageUrl": "https://www.kroger.com/product/images/small/front/0000000004648",
+					"detailUrl": "/p/item/0000000004648",
+					"sellableUpc": "0000000004648",
+					"containerDeposit": false,
+					"managerOverride": false,
+					"weighted": true,
+					"giftCard": false,
+					"pharmacy": false,
+					"fuel": false,
+					"managerOverrideIgnored": false
 				}
 			],
 			"transactionTime": "2020-03-21T09:14:00"

--- a/tests/testdata/receipts_expected.json
+++ b/tests/testdata/receipts_expected.json
@@ -1,0 +1,18 @@
+[{
+    "name": "Twix Minis Size Chocolate Cookie Bars",
+    "location_id": 2,
+    "qu_id_purchase": 3,
+    "qu_id_stock": 3,
+    "barcode": "0040000525509",
+    "quantity": 1,
+    "transaction_date": "2020-03-21"
+}, {
+    "name": "Franz Extra Crisp English Muffins",
+    "location_id": 2,
+    "qu_id_purchase": 3,
+    "qu_id_stock": 3,
+    "barcode": "0072220005165",
+    "quantity": 3,
+    "transaction_date": "2020-03-21"
+}
+]

--- a/tests/testdata/receipts_expected.json
+++ b/tests/testdata/receipts_expected.json
@@ -14,5 +14,17 @@
     "barcode": "0072220005165",
     "quantity": 3,
     "transaction_date": "2020-03-21"
+}, {
+    "name": "Mushrooms - Crimini - Bulk",
+    "location_id": 3,
+    "qu_id_purchase": 2,
+    "qu_id_stock": 2,
+    "qu_factor_purchase_to_stock": 1,
+    "barcode": "0000000046480",
+    "default_best_before_days": 21,
+    "quantity": 0.84,
+    "transaction_date": "2020-03-21",
+    "price_paid": 3.988095238095238,
+    "picture_url": "https:\/\/www.kroger.com\/product\/images\/small\/front\/0000000004648"
 }
 ]

--- a/tests/testdata/receipts_expected.json
+++ b/tests/testdata/receipts_expected.json
@@ -1,6 +1,6 @@
 [{
     "name": "Twix Minis Size Chocolate Cookie Bars",
-    "location_id": 2,
+    "location_id": 4,
     "qu_id_purchase": 3,
     "qu_id_stock": 3,
     "barcode": "0040000525509",
@@ -8,7 +8,7 @@
     "transaction_date": "2020-03-21"
 }, {
     "name": "Franz Extra Crisp English Muffins",
-    "location_id": 2,
+    "location_id": 3,
     "qu_id_purchase": 3,
     "qu_id_stock": 3,
     "barcode": "0072220005165",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"Version": "2.6.2",
+	"Version": "2.6.3",
 	"ReleaseDate": "2020-03-29"
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"Version": "2.6.3",
+	"Version": "2.6.2",
 	"ReleaseDate": "2020-03-29"
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"Version": "2.6.1",
-	"ReleaseDate": "2020-03-06"
+	"Version": "2.6.2",
+	"ReleaseDate": "2020-03-29"
 }

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -209,7 +209,7 @@
 				@if(GROCY_FEATURE_FLAG_UPLOAD_JSON)
 				<li class="nav-item nav-item-sidebar" data-toggle="tooltip" data-placement="right" title="{{ $__t('Upload json') }}" data-nav-for-page="upload-json">
 					<a class="nav-link discrete-link" href="{{ $U('/uploadjson') }}">
-						<i class="fas fa-fire"></i>
+						<i class="fas fa-code"></i>
 						<span class="nav-link-text">{{ $__t('Upload Json') }}</span>
 					</a>
 				</li>

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -206,6 +206,14 @@
 					</a>
 				</li>
 				@endif
+				@if(GROCY_FEATURE_FLAG_UPLOAD_JSON)
+				<li class="nav-item nav-item-sidebar" data-toggle="tooltip" data-placement="right" title="{{ $__t('Upload json') }}" data-nav-for-page="upload-json">
+					<a class="nav-link discrete-link" href="{{ $U('/uploadjson') }}">
+						<i class="fas fa-fire"></i>
+						<span class="nav-link-text">{{ $__t('Upload Json') }}</span>
+					</a>
+				</li>
+				@endif
 
 				@php $firstUserentity = true; @endphp
 				@foreach($userentitiesForSidebar as $userentity)

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -260,6 +260,10 @@
 					<input type="file" class="custom-file-input" id="product-picture" accept="image/*">
 					<label class="custom-file-label" for="product-picture">{{ $__t('No file selected') }}</label>
 				</div>
+				
+				@if(!empty($product->picture_url))
+					<input type="hidden" name="picture_url" value="{{ $product->picture_url }}" />
+				@endif
 			</div>
 
 			@include('components.userfieldsform', array(

--- a/views/products.blade.php
+++ b/views/products.blade.php
@@ -71,7 +71,7 @@
 						</a>
 					</td>
 					<td>
-						{{ $product->name }}@if(!empty($product->picture_file_name)) <i class="fas fa-image text-muted"></i>@endif
+						{{ $product->name }}@if(!empty($product->picture_file_name) || !empty($product->picture_url)) <i class="fas fa-image text-muted"></i>@endif
 					</td>
 					<td class="@if(!GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING) d-none @endif">
 						{{ FindObjectInArrayByPropertyValue($locations, 'id', $product->location_id)->name }}

--- a/views/uploadjson.blade.php
+++ b/views/uploadjson.blade.php
@@ -1,0 +1,71 @@
+@extends('layout.default')
+
+@section('title', $__t('Upload Purchase Data As JSON'))
+@section('activeNav', 'uploadjson')
+@section('viewJsName', 'uploadjson')
+
+@section('content')
+<div class="row">
+	<div class="col-md-12">
+		<h1>
+			@yield('title')
+		</h1>
+	</div>
+</div>
+<div class="row">
+	<div class="col-lg-6 col-xs-12">
+		<form id="json-form" novalidate>
+
+			@if(GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING)
+			<div class="form-group">
+				<label for="location_id">{{ $__t('Default location ') . $location->name }}</label>
+				<p class="small text-muted">{{ $__t('Change this value in user settings') }}</p>
+			</div>
+			@endif
+			
+			<div class="form-group">
+				<label for="qu_id_purchase">{{ $__t('Default Quantity unit ') . $quantityunit->name }}</label>
+				<p class="small text-muted">{{ $__t('Change this value in user settings') }}</p>
+			</div>
+			
+			<div class="form-group">
+				<label for="shopping_location_id">{{ $__t('Default store') }}</label>
+				<select class="form-control input-group-qu" id="shopping_location_id" name="shopping_location_id">
+					<option></option>
+					@foreach($shoppinglocations as $location)
+						<option value="{{ $location->id }}">{{ $location->name }}</option>
+					@endforeach
+				</select>
+			</div>
+
+			<div class="form-group">
+				<div class="form-check">
+					<input class="form-check-input" type="checkbox" id="dont_add_to_stock" name="dont_add_to_stock" value="1">
+					<label class="form-check-label" for="dont_add_to_stock">{{ $__t("Don't add to stock") }}</label>
+				</div>
+			</div>
+
+            <div class="form-group">
+                <label for="json-data">{{ $__t('JSON Data') }}</label>
+                <textarea class="form-control" rows="75" id="json-data" name="json-data" placeholder="{'data': [{'items': [{}]}] }"></textarea>
+            </div>
+
+			<button id="upload-json-button" class="btn btn-success d-block">{{ $__t('OK') }}</button>
+
+		</form>
+	</div>
+	<div class="col-lg-6 col-xs-12">
+		<p>
+			{{ $__t("Kroger grocery stores allow manual access to past purchases in json form 
+			through a browser's developer tools.") }}
+		</p>
+		<p>
+			{{ $__t("To get this json, open developer tools
+			and navigate to https://www.qfc.com/mypurchases (or another Kroger grocer,
+			such as https://www.fredmeyer.com/mypurchases) and look for a call to 
+			/mypurchases/api/v1/receipt/details.  The response will contain data for the
+			last five receipts.") }}
+		</p>
+	</div>
+</div>
+@stop


### PR DESCRIPTION
I shop at Kroger grocery stores (QFC, Fred Meyer, etc.), so I wanted to be able to import my purchases from their api.  Unfortunately, the Kroger api doesn't allow access to purchases, BUT through their website you can access purchase data in json format.  This change allows us to import that data into our database.

Here is a gif of the process and result: ![grocy_kroger](https://user-images.githubusercontent.com/1863280/78208123-72315080-7458-11ea-88e9-83f2f5789242.gif)

The main changes are as follows:

- Added KrogerToGrocyConverter that is in charge of converting the Kroger json data to the Grocy equivalent.  It is able to pull quite a bit of information from the json data.  Specifically:
    - Quantity
    - Price
    - Location - can be guessed based on product category
    - Barcode - translated from UPC
    - Picture - they give a picture url if it exists
If the location or quantity unit cannot be determined, I use the location or quantity unit from user settings.  Everything else have reasonable defaults.

- Added a menu option to "Upload JSON".  The form has only a few options but definitely room to grow.

- Added a few unit tests for the converter.  I noticed there weren't unit tests in the whole project.  Not sure how you've lived without them; I'd be happy to add more if they'd be appreciated.
