### PR TITLE
favicon.ico retrieval: Specify profile for rel='icon', following W3C howto

### DIFF
--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ GROCY_CULTURE }}">
-<head>
+<head profile="http://www.w3.org/2005/10/profile">
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
From reading the [W3C How to Add a Favicon to your Site](https://www.w3.org/2005/10/howto-favicon) it looks like specifying a '[profile](https://www.w3.org/2005/10/howto-favicon#profile)' may encourage browsers to retrieve page icons from the correct path.

Caveat: I have not yet been able to test this locally. 

Resolves #691