### PR TITLE
Create the backup tarball explicitly before invoking tar

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,7 @@ pushd `dirname $0` > /dev/null
 backupBundleFileName="backup-`date +%d-%m-%Y-%H-%M-%S`.tgz"
 echo Making a backup of the current installation in ./data/backups/$backupBundleFileName
 mkdir -p ./data/backups > /dev/null
+touch ./data/backups/$backupBundleFileName
 tar -zcvf ./data/backups/$backupBundleFileName --exclude ./data/backups . > /dev/null
 find ./data/backups/*.tgz -mtime +60 -type f -delete
 


### PR DESCRIPTION
When grocy is installed on a btrfs file system, the `tar` command used in the backup step of the `upgrade.sh` script fails if the tarball is not created first.

The result without creating the tarball looks like this:
```
tar: ./data: file changed as we read it
```

If we use the `touch` command to create a file with the same name as the tarball first, the upgrade works as expected.