### PR TITLE
Add missing form validation on presetting QU id stock

### DIFF
--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -431,5 +431,6 @@ $('#qu_id_purchase').blur(function(e)
 	var QuIdPurchase = $('#qu_id_purchase');
 	if (QuIdStock[0].selectedIndex === 0 && QuIdPurchase[0].selectedIndex !== 0) {
 		QuIdStock[0].selectedIndex = QuIdPurchase[0].selectedIndex;
+		Grocy.FrontendHelpers.ValidateForm('product-form');
 	}
 });


### PR DESCRIPTION
The *Save* button didn't become clickable after presetting QU stock Id with QU purchase Id.