### PR TITLE
Add email

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 		"gettext/gettext": "^4.8",
 		"eluceo/ical": "^0.16.0",
 		"erusev/parsedown": "^1.7",
-		"gumlet/php-image-resize": "^1.9"
+		"gumlet/php-image-resize": "^1.9",
+		"phpmailer/phpmailer": "^6.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70c5b65f78f4eb43dac8df8dc144e56c",
+    "content-hash": "5ede5e5e43e0c1c8c2160f6837105b7f",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1157,6 +1157,68 @@
             "time": "2019-09-26T11:24:58+00:00"
         },
         {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "a8bf068f64a580302026e484ee29511f661b2ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/a8bf068f64a580302026e484ee29511f661b2ad3",
+                "reference": "a8bf068f64a580302026e484ee29511f661b2ad3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.2",
+                "friendsofphp/php-cs-fixer": "^2.2",
+                "phpunit/phpunit": "^4.8 || ^5.7"
+            },
+            "suggest": {
+                "ext-mbstring": "Needed to send email in multibyte encoding charset",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "stevenmaguire/oauth2-microsoft": "Needed for Microsoft XOAUTH2 authentication",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "time": "2020-03-14T14:23:48+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -2256,6 +2318,5 @@
     "platform": {
         "php": ">=7.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/config-dist.php
+++ b/config-dist.php
@@ -74,6 +74,14 @@ Setting('DISABLE_BROWSER_BARCODE_CAMERA_SCANNING', false);
 # Needs to be a number where Sunday = 0, Monday = 1 and so forth
 Setting('MEAL_PLAN_FIRST_DAY_OF_WEEK', '');
 
+# Email smtp settings
+Setting('EMAIL_HOST','smtp.gmail.com');
+Setting('EMAIL_PORT','587');
+Setting('EMAIL_USERNAME','');
+Setting('EMAIL_PASSWORD','');
+Setting('EMAIL_FROM','from@example.com, from who');
+Setting('EMAIL_REPLYTO','noreply@example.com, No Reply');
+
 
 # Default user settings
 # These settings can be changed per user, here the defaults

--- a/controllers/UsersApiController.php
+++ b/controllers/UsersApiController.php
@@ -32,7 +32,7 @@ class UsersApiController extends BaseApiController
 				throw new \Exception('Request body could not be parsed (probably invalid JSON format or missing/wrong Content-Type header)');
 			}
 
-			$this->getUsersService()->CreateUser($requestBody['username'], $requestBody['first_name'], $requestBody['last_name'], $requestBody['password']);
+			$this->getUsersService()->CreateUser($requestBody['username'], $requestBody['email'], $requestBody['first_name'], $requestBody['last_name'], $requestBody['password']);
 			return $this->EmptyApiResponse($response);
 		}
 		catch (\Exception $ex)
@@ -60,7 +60,7 @@ class UsersApiController extends BaseApiController
 
 		try
 		{
-			$this->getUsersService()->EditUser($args['userId'], $requestBody['username'], $requestBody['first_name'], $requestBody['last_name'], $requestBody['password']);
+			$this->getUsersService()->EditUser($args['userId'], $requestBody['username'], $requestBody['email'], $requestBody['first_name'], $requestBody['last_name'], $requestBody['password']);
 			return $this->EmptyApiResponse($response);
 		}
 		catch (\Exception $ex)

--- a/migrations/0100.sql
+++ b/migrations/0100.sql
@@ -40,3 +40,13 @@ JOIN stock s
 WHERE pr.parent_product_id != pr.sub_product_id
 GROUP BY pr.sub_product_id
 HAVING SUM(s.amount) > 0;
+
+ALTER TABLE users
+ADD email TEXT;
+
+CREATE TABLE password_reset_temp (
+	id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,
+	email TEXT NOT NULL UNIQUE,
+	key TEXT,
+	expiration_date DATETIME NOT NULL
+);

--- a/services/UsersService.php
+++ b/services/UsersService.php
@@ -4,10 +4,11 @@ namespace Grocy\Services;
 
 class UsersService extends BaseService
 {
-	public function CreateUser(string $username, string $firstName, string $lastName, string $password)
+	public function CreateUser(string $username, string $email, string $firstName, string $lastName, string $password)
 	{
 		$newUserRow = $this->getDatabase()->users()->createRow(array(
 			'username' => $username,
+			'email' => $email,
 			'first_name' => $firstName,
 			'last_name' => $lastName,
 			'password' => password_hash($password, PASSWORD_DEFAULT)
@@ -15,7 +16,7 @@ class UsersService extends BaseService
 		$newUserRow->save();
 	}
 
-	public function EditUser(int $userId, string $username, string $firstName, string $lastName, string $password)
+	public function EditUser(int $userId, string $username, string $email, string $firstName, string $lastName, string $password)
 	{
 		if (!$this->UserExists($userId))
 		{
@@ -25,6 +26,7 @@ class UsersService extends BaseService
 		$user = $this->getDatabase()->users($userId);
 		$user->update(array(
 			'username' => $username,
+			'email' => $email,
 			'first_name' => $firstName,
 			'last_name' => $lastName,
 			'password' => password_hash($password, PASSWORD_DEFAULT)

--- a/views/userform.blade.php
+++ b/views/userform.blade.php
@@ -28,6 +28,12 @@
 			</div>
 
 			<div class="form-group">
+				<label for="email">{{ $__t('Email') }}</label>
+				<input type="text" class="form-control" required id="email" name="email" value="@if($mode == 'edit'){{ $user->email }}@endif">
+				<div class="invalid-feedback">{{ $__t('An email is required') }}</div>
+			</div>
+
+			<div class="form-group">
 				<label for="first_name">{{ $__t('First name') }}</label>
 				<input type="text" class="form-control" id="first_name" name="first_name" value="@if($mode == 'edit'){{ $user->first_name }}@endif">
 			</div>

--- a/views/users.blade.php
+++ b/views/users.blade.php
@@ -30,6 +30,7 @@
 				<tr>
 					<th class="border-right"></th>
 					<th>{{ $__t('Username') }}</th>
+					<th>{{ $__t('Email') }}</th>
 					<th>{{ $__t('First name') }}</th>
 					<th>{{ $__t('Last name') }}</th>
 				</tr>
@@ -47,6 +48,9 @@
 					</td>
 					<td>
 						{{ $user->username }}
+					</td>
+					<td>
+						{{ $user->email }}
 					</td>
 					<td>
 						{{ $user->first_name }}


### PR DESCRIPTION
WIP 

These current two commits just lay some framework to add Email to the users, add phpmailer, and a possible table for user password reset.

Initially taking a look at this link
https://www.allphptricks.com/forgot-password-recovery-reset-using-php-and-mysql/

I think the next step is to make a ResetUserPassword in the UserApiController, what do you think?
Have you looked a phpmailer or did you have something else in mind for emails?