### PR TITLE
Remove NodeJS dependency check

### DIFF
--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -11,7 +11,6 @@ class PrerequisiteChecker
         self::checkForConfigFile();
         self::checkForConfigDistFile();
         self::checkForComposer();
-        self::checkForYarn();
         self::checkForPhpExtensions();
     }
     
@@ -37,14 +36,6 @@ class PrerequisiteChecker
         if (!file_exists(__DIR__ . '/../vendor/autoload.php'))
         {
             throw new ERequirementNotMet('/vendor/autoload.php not found. Have you run Composer?');
-        }
-    }
-
-    private function checkForYarn()
-    {
-        if (!file_exists(__DIR__ . '/../public/node_modules'))
-        {
-            throw new ERequirementNotMet('/public/node_modules not found. Have you run Yarn?');
         }
     }
 


### PR DESCRIPTION
It may be worth performing this NodeJS dependency validation check outside of the `grocy` application.

PHP code is well-suited to self-test for presence of configuration file and PHP library dependencies, while other infrastructure may be better suited to check for the presence and integrity of static content.

Previous `grocy` zipfile releases have included the full PHP and NodeJS file dependencies in the expected file path locations.  If that convention continues, then users deploying a simple installation from a release zipfile should be unlikely to encounter situations where PHP requirements are fulfilled and yet NodeJS dependencies are missing.

Fixes #744 