### PR TITLE
Fixed Timezone in CalendarApiController

### DIFF
--- a/controllers/CalendarApiController.php
+++ b/controllers/CalendarApiController.php
@@ -19,7 +19,7 @@ class CalendarApiController extends BaseApiController
 			foreach($events as $event)
 			{
 				$date = new \DateTime($event['start']);
-				$date->setTimezone(date_default_timezone_get());
+				$date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 				if ($event['date_format'] === 'date')
 				{


### PR DESCRIPTION
`PHP Warning:  DateTime::setTimezone() expects parameter 1 to be DateTimeZone, string given in /var/www/grocy/controllers/CalendarApiController.php on line 22`