### PR TITLE
Purchase Price Hints

### DIFF
--- a/public/viewjs/components/productcard.js
+++ b/public/viewjs/components/productcard.js
@@ -80,7 +80,7 @@ Grocy.Components.ProductCard.Refresh = function(productId)
 
 			if (productDetails.last_price !== null)
 			{
-				$('#productcard-product-last-price').text(Number.parseFloat(productDetails.last_price).toLocaleString() + ' ' + Grocy.Currency);
+				$('#productcard-product-last-price').text(Number.parseFloat(productDetails.last_price).toLocaleString() + ' ' + Grocy.Currency + ' per ' + productDetails.quantity_unit_purchase.name);
 			}
 			else
 			{

--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -161,6 +161,8 @@ if (Grocy.Components.ProductPicker !== undefined)
 						Grocy.Components.LocationPicker.SetId(productDetails.location.id);
 					}
 
+					$('#amount_qu_unit').attr("qu-factor-purchase-to-stock", productDetails.product.qu_factor_purchase_to_stock);
+					$('#amount_qu_unit').attr("quantity-unit-stock-name", productDetails.quantity_unit_stock.name);
 					if (productDetails.product.qu_id_purchase === productDetails.product.qu_id_stock)
 					{
 						$('#amount_qu_unit').text(productDetails.quantity_unit_purchase.name);
@@ -169,6 +171,12 @@ if (Grocy.Components.ProductPicker !== undefined)
 					{
 						$('#amount_qu_unit').text(productDetails.quantity_unit_purchase.name + " (" + __t("will be multiplied by a factor of %1$s to get %2$s", parseFloat(productDetails.product.qu_factor_purchase_to_stock).toLocaleString({ minimumFractionDigits: 0, maximumFractionDigits: 2 }), __n(2, productDetails.quantity_unit_stock.name, productDetails.quantity_unit_stock.name_plural)) + ")");
 					}
+
+					var priceTypeUnitPrice = $("#price-type-unit-price");
+					var priceTypeUnitPriceLabel = $("[for=" + priceTypeUnitPrice.attr("id") + "]");
+					priceTypeUnitPriceLabel.text(productDetails.quantity_unit_purchase.name + " price");
+
+					refreshPriceHint();
 
 					if (productDetails.product.allow_partial_units_in_stock == 1)
 					{
@@ -320,8 +328,24 @@ if (Grocy.Components.DateTimePicker)
 	});
 }
 
+$('#price').on('change', function(e)
+{
+	refreshPriceHint();
+});
+
+$('#price-type-unit-price').on('change', function(e)
+{
+	refreshPriceHint();
+});
+
+$('#price-type-total-price').on('change', function(e)
+{
+	refreshPriceHint();
+});
+
 $('#amount').on('change', function(e)
 {
+	refreshPriceHint();
 	Grocy.FrontendHelpers.ValidateForm('purchase-form');
 });
 
@@ -329,6 +353,42 @@ if (GetUriParam("flow") === "shoppinglistitemtostock")
 {
 	$('#amount').val(parseFloat(GetUriParam("amount")).toLocaleString({ minimumFractionDigits: 0, maximumFractionDigits: 4 }));
 }
+
+function refreshPriceHint()
+{
+
+	if ($('#amount').val() == 0)
+	{
+		$('#price-hint').text("");
+		return;
+	}
+	if ($('#price').val() == 0)
+	{
+		$('#price-hint').text("");
+		return;
+	}
+
+	if ($("input[name='price-type']:checked").val() == "total-price")
+	{
+		var priceTypeUnitPrice = $("#price-type-unit-price");
+		var priceTypeUnitPriceLabel = $("[for=" + priceTypeUnitPrice.attr("id") + "]");
+		var price = $('#price').val() / $('#amount').val();
+
+		$('#price-hint').text('(will result with ' + priceTypeUnitPriceLabel.text() + ' cost of ' + price.toFixed(2) + ')');
+	}
+	else
+	{
+		if (document.getElementById("amount_qu_unit").getAttribute("qu-factor-purchase-to-stock") > 1)
+		{
+			var price = $('#price').val() / document.getElementById("amount_qu_unit").getAttribute("qu-factor-purchase-to-stock");
+			$('#price-hint').text('(will result with ' + document.getElementById("amount_qu_unit").getAttribute("quantity-unit-stock-name") + ' cost of ' + price.toFixed(2) + ')');
+		}
+		else
+		{
+			$('#price-hint').text("");
+		}
+	}
+};
 
 function UndoStockBooking(bookingId)
 {

--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -222,19 +222,9 @@ if (Grocy.Components.ProductPicker !== undefined)
 						{
 							Grocy.Components.DateTimePicker.SetValue(moment().add(productDetails.product.default_best_before_days, 'days').format('YYYY-MM-DD'));
 						}
-						$('#amount').focus();
 					}
-					else
-					{
-						if (Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
-						{
-							Grocy.Components.DateTimePicker.GetInputElement().focus();
-						}
-						else
-						{
-							$('#amount').focus();
-						}
-					}
+
+					$("#amount").focus();
 
 					Grocy.FrontendHelpers.ValidateForm('purchase-form');
 					if (GetUriParam("flow") === "shoppinglistitemtostock" && BoolVal(Grocy.UserSettings.shopping_list_to_stock_workflow_auto_submit_when_prefilled) && document.getElementById("purchase-form").checkValidity() === true)

--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -206,7 +206,7 @@ if (Grocy.Components.ProductPicker !== undefined)
 
 					if (!Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
 					{
-						Grocy.Components.DateTimePicker.SetValue(moment().format('YYYY-MM-DD'));
+						Grocy.Components.DateTimePicker.SetValue('2999-12-31');
 					}
 
 					if (productDetails.product.default_best_before_days.toString() !== '0')

--- a/views/purchase.blade.php
+++ b/views/purchase.blade.php
@@ -30,9 +30,17 @@
 
 			@include('components.productpicker', array(
 				'products' => $products,
-				'nextInputSelector' => '#best_before_date .datetimepicker-input'
+				'nextInputSelector' => '#amount'
 			))
 
+			@include('components.numberpicker', array(
+				'id' => 'amount',
+				'label' => 'Amount',
+				'hintId' => 'amount_qu_unit',
+				'min' => 1,
+				'invalidFeedback' => $__t('The amount cannot be lower than %s', '1'),
+				'additionalHtmlContextHelp' => '<div id="tare-weight-handling-info" class="text-info font-italic d-none">' . $__t('Tare weight handling enabled - please weigh the whole container, the amount to be posted will be automatically calculcated') . '</div>'
+			))
 
 			@php
 				$additionalGroupCssClasses = '';
@@ -49,7 +57,7 @@
 				'limitEndToNow' => false,
 				'limitStartToNow' => false,
 				'invalidFeedback' => $__t('A best before date is required'),
-				'nextInputSelector' => '#amount',
+				'nextInputSelector' => '#price',
 				'additionalCssClasses' => 'date-only-datetimepicker',
 				'shortcutValue' => '2999-12-31',
 				'shortcutLabel' => 'Never expires',
@@ -59,15 +67,6 @@
 				'activateNumberPad' => GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_FIELD_NUMBER_PAD
 			))
 			@php $additionalGroupCssClasses = ''; @endphp
-
-			@include('components.numberpicker', array(
-				'id' => 'amount',
-				'label' => 'Amount',
-				'hintId' => 'amount_qu_unit',
-				'min' => 1,
-				'invalidFeedback' => $__t('The amount cannot be lower than %s', '1'),
-				'additionalHtmlContextHelp' => '<div id="tare-weight-handling-info" class="text-info font-italic d-none">' . $__t('Tare weight handling enabled - please weigh the whole container, the amount to be posted will be automatically calculcated') . '</div>'
-			))
 
 			@if(GROCY_FEATURE_FLAG_STOCK_PRICE_TRACKING)
 			@include('components.numberpicker', array(

--- a/views/purchase.blade.php
+++ b/views/purchase.blade.php
@@ -76,14 +76,14 @@
 				'min' => 0,
 				'step' => 0.01,
 				'value' => '',
-				'hint' => $__t('in %s and based on the purchase quantity unit', GROCY_CURRENCY),
+				'hintId' => 'price-hint',
 				'invalidFeedback' => $__t('The price cannot be lower than %s', '0'),
 				'isRequired' => false,
 				'additionalGroupCssClasses' => 'mb-1'
 			))
 			<div class="form-check form-check-inline mb-3">
 				<input class="form-check-input" type="radio" name="price-type" id="price-type-unit-price" value="unit-price" checked>
-				<label class="form-check-label" for="price-type-unit-price">{{ $__t('Unit price') }}</label>
+				<label class="form-check-label" for="price-type-unit-price">{{ $__t('Price') }}</label>
 			</div>
 			<div class="form-check form-check-inline mb-3">
 				<input class="form-check-input" type="radio" name="price-type" id="price-type-total-price" value="total-price">


### PR DESCRIPTION
A number of items to review

- Update products_average_price view with rounding
- Add average price to added to product card
- Recipe costs, use default consume rule which is "First expiring first, then first in first out"
   Achieved by updating the recipes_pos_resolved to use the new products_oldest_price view
- Update product details to use products_last_purchased view to reduce db calls
- deprecate products_current_price due to using products_last_purchased and changing recipe_pos_resolved

**update to recipe costs calculation in recipes_pos_resolved**
- when using only_check_single_unit_in_stock, now set the case to use 0 so that the costs is not included in the recipe costs. Logic is, if the product will not be consumed, then why add it to the costs?
- move rp.amount outside of if statement to always be used
- remove logic divisor of p.qu_factor_purchase_to_stock, the stock price is saved at the qu level and not the purchase level so is not necessary
