### PR TITLE
Make GetUriParam work with special characters (eg. "&")

### DIFF
--- a/public/js/extensions.js
+++ b/public/js/extensions.js
@@ -23,7 +23,7 @@ String.prototype.replaceAll = function(search, replacement)
 
 GetUriParam = function(key)
 {
-	var currentUri = decodeURIComponent(window.location.search.substring(1));
+	var currentUri = window.location.search.substring(1);
 	var vars = currentUri.split('&');
 
 	for (i = 0; i < vars.length; i++)
@@ -32,7 +32,7 @@ GetUriParam = function(key)
 
 		if (currentParam[0] === key)
 		{
-			return currentParam[1] === undefined ? true : currentParam[1];
+			return currentParam[1] === undefined ? true : decodeURIComponent(currentParam[1]);
 		}
 	}
 };


### PR DESCRIPTION
If a special character like "&" is passed URL encoded, grocy decoded it before parsing. That way if an ampersand was in a variable, the ampersand and everything after was ignored.

To reproduce: https://demo.grocy.info/product/new?closeAfterCreation&prefillname=Ben%20%26%20Jerry%27s%20Glace%20Cookie%20Dough%20Vanille%20500%20ml&prefillbarcode=0076840600021