### PR TITLE
Additional configuration options for Quagga2

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -126,9 +126,14 @@ DefaultUserSetting('auto_reload_on_db_change', true);
 # Show a clock in the header next to the logo or not
 DefaultUserSetting('show_clock_in_header', false);
 
-# Component configuration
+# Component configuration for Quagga2 - read https://github.com/ericblade/quagga2#configobject for details
+# Default for Grocy is as below
+# For iPhone 7 PLus, halfsample = true, patchsize = small, frequency = 5 yields very good results
 DefaultUserSetting('quagga2_numofworkers', 4);
-
+DefaultUserSetting('quagga2_halfsample', false);
+DefaultUserSetting('quagga2_patchsize', 'medium');
+DefaultUserSetting('quagga2_frequency', 10);
+DefaultUserSetting('quagga2_debug', true);
 
 # Feature flags
 # grocy was initially about "stock management for your household", many other things

--- a/public/viewjs/components/barcodescanner.js
+++ b/public/viewjs/components/barcodescanner.js
@@ -69,25 +69,25 @@ Grocy.Components.BarcodeScanner.StartScanning = function()
 			}
 		},
 		locator: {
-			patchSize: "medium",
-			halfSample: false,
+			patchSize: Grocy.UserSettings.quagga2_patchsize,
+			halfSample: Grocy.UserSettings.quagga2_halfsample,
 			debug: {
-				showCanvas: true,
-				showPatches: true,
-				showFoundPatches: true,
-				showSkeleton: true,
-				showLabels: true,
-				showPatchLabels: true,
-				showRemainingPatchLabels: true,
+				showCanvas: Grocy.UserSettings.quagga2_debug,
+				showPatches: Grocy.UserSettings.quagga2_debug,
+				showFoundPatches: Grocy.UserSettings.quagga2_debug,
+				showSkeleton: Grocy.UserSettings.quagga2_debug,
+				showLabels: Grocy.UserSettings.quagga2_debug,
+				showPatchLabels: Grocy.UserSettings.quagga2_debug,
+				showRemainingPatchLabels: Grocy.UserSettings.quagga2_debug,
 				boxFromPatches: {
-					showTransformed: true,
-					showTransformedBox: true,
-					showBB: true
+					showTransformed: Grocy.UserSettings.quagga2_debug,
+					showTransformedBox: Grocy.UserSettings.quagga2_debug,
+					showBB: Grocy.UserSettings.quagga2_debug
 				}
 			}
 		},
 		numOfWorkers: Grocy.UserSettings.quagga2_numofworkers,
-		frequency: 10,
+		frequency: Grocy.UserSettings.quagga2_frequency,
 		decoder: {
 			readers: [
 				"ean_reader",
@@ -95,17 +95,17 @@ Grocy.Components.BarcodeScanner.StartScanning = function()
 				"code_128_reader"
 			],
 			debug: {
-				showCanvas: true,
-				showPatches: true,
-				showFoundPatches: true,
-				showSkeleton: true,
-				showLabels: true,
-				showPatchLabels: true,
-				showRemainingPatchLabels: true,
+				showCanvas: Grocy.UserSettings.quagga2_debug,
+				showPatches: Grocy.UserSettings.quagga2_debug,
+				showFoundPatches: Grocy.UserSettings.quagga2_debug,
+				showSkeleton: Grocy.UserSettings.quagga2_debug,
+				showLabels: Grocy.UserSettings.quagga2_debug,
+				showPatchLabels: Grocy.UserSettings.quagga2_debug,
+				showRemainingPatchLabels: Grocy.UserSettings.quagga2_debug,
 				boxFromPatches: {
-					showTransformed: true,
-					showTransformedBox: true,
-					showBB: true
+					showTransformed: Grocy.UserSettings.quagga2_debug,
+					showTransformedBox: Grocy.UserSettings.quagga2_debug,
+					showBB: Grocy.UserSettings.quagga2_debug
 				}
 			}
 		},


### PR DESCRIPTION
Hello, @berrnd.

This is an initial commit for review and discussion.

When trying to make the barcode scanner work on Grocy on my iPhone, I had to tweak some of the Quagga settings to achieve optimal results, which differ from the default. For example, to me I need to set halfSample to true, patchSize to small and frequency to 5. These took lots of time to tweak, and I thought a PR enabling these configurations on config.php along with numOfWorkers might be valuable to some users. Also, to enhance performance, I added an option to enable/disable the debug options for Quagga.