### PR TITLE
Make product amount picker locale independent

### DIFF
--- a/public/viewjs/components/productamountpicker.js
+++ b/public/viewjs/components/productamountpicker.js
@@ -83,7 +83,7 @@ $(".input-group-productamountpicker").on("change", function()
 		$("#qu-conversion-info").text(__t("This equals %1$s %2$s in stock", destinationAmount.toLocaleString(), destinationQuName));
 	}
 
-	$("#amount").val(destinationAmount.toLocaleString({ minimumFractionDigits: 0, maximumFractionDigits: 4 }));
+	$("#amount").val(destinationAmount.toFixed(4).replace(/0*$/g,''));
 });
 
 $("#display_amount").on("keyup", function()


### PR DESCRIPTION
Since the value of $('#amount') will be written to the database it should not be locale dependent. This code also limits the result to a maximum of 4 digits but always uses a dot as decimal separator.