### PR TITLE
WIP: Fix typo on "Consumed Amount" localization string

### DIFF
--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "this location"
 msgstr ""
 
-msgid "Consumend amount"
+msgid "Consumed amount"
 msgstr ""
 
 msgid "Time of printing"

--- a/views/locationcontentsheet.blade.php
+++ b/views/locationcontentsheet.blade.php
@@ -58,7 +58,7 @@
 					<tr>
 						<th>{{ $__t('Product') }}</th>
 						<th>{{ $__t('Amount') }}</th>
-						<th>{{ $__t('Consumend amount') . ' / ' . $__t('Notes') }}</th>
+						<th>{{ $__t('Consumed amount') . ' / ' . $__t('Notes') }}</th>
 					</tr>
 				</thead>
 				<tbody>


### PR DESCRIPTION
The ID "Consumend Amount" should fairly obvously be "Consumed Amount" instead.

This was bugging me quite a bit when fooling around in the interface, so here's a PR to fix it!