### PR TITLE
Fix amount in recipes ingridients

### DIFF
--- a/public/viewjs/recipeposform.js
+++ b/public/viewjs/recipeposform.js
@@ -6,6 +6,7 @@ $('#save-recipe-pos-button').on('click', function (e)
 
 	var jsonData = $('#recipe-pos-form').serializeJSON({ checkboxUncheckedValue: "0" });
 	jsonData.recipe_id = Grocy.EditObjectParentId;
+    jsonData.amount = jsonData.amount.replace(/\s/g, '');
 	delete jsonData.display_amount;
 
 	Grocy.FrontendHelpers.BeginUiBusy("recipe-pos-form");


### PR DESCRIPTION
When amount in recipie ingridients is over 1000, it is sent to API as `"amount": "1 000"` and is saved in DB the same way. It displays in UI then as 1 and seems that counts same way when calculated stock items for recipie.
Removing spaces in amount value before sending it to API fixes this issue.