### PR TITLE
Docker development environment and start script

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,77 @@
+FROM php:7.3-apache
+
+# Enable Apache Rewrite + Expires Module
+RUN a2enmod rewrite expires
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    unzip \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libyaml-dev \
+    libzip4 \
+    libzip-dev \
+    zlib1g-dev \
+    libicu-dev \
+    g++ \
+    git \
+    cron \
+    vim \
+    curl \
+    unzip \
+    gnupg2 \
+    && docker-php-ext-install opcache \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-install zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=2'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+    echo 'upload_max_filesize=128M'; \
+    echo 'post_max_size=128M'; \
+    } > /usr/local/etc/php/conf.d/php-recommended.ini
+
+RUN pecl install apcu \
+    && pecl install yaml-2.0.4 \
+    && docker-php-ext-enable apcu yaml
+
+RUN curl -s https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get -y install yarn && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set user to www-data
+# RUN chown www-data:www-data /var/www
+USER www-data
+
+# Copy files
+COPY ./ /var/www/html
+
+# Return to root user
+USER root
+RUN chown -R www-data:www-data /var/www
+RUN chmod -R 777 /var/www
+
+USER www-data
+WORKDIR /var/www/html
+RUN composer install && \
+    yarn install
+
+USER root
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,77 +1,44 @@
 FROM php:7.3-apache
 
+# Install composer from official image
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 # Enable Apache Rewrite + Expires Module
 RUN a2enmod rewrite expires
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    unzip \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
     libyaml-dev \
-    libzip4 \
-    libzip-dev \
     zlib1g-dev \
-    libicu-dev \
-    g++ \
     git \
-    cron \
-    vim \
     curl \
-    unzip \
     gnupg2 \
-    && docker-php-ext-install opcache \
-    && docker-php-ext-configure intl \
-    && docker-php-ext-install intl \
+    unzip \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
-    && docker-php-ext-install zip \
     && rm -rf /var/lib/apt/lists/*
-
-# set recommended PHP.ini settings
-# see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-    echo 'opcache.memory_consumption=128'; \
-    echo 'opcache.interned_strings_buffer=8'; \
-    echo 'opcache.max_accelerated_files=4000'; \
-    echo 'opcache.revalidate_freq=2'; \
-    echo 'opcache.fast_shutdown=1'; \
-    echo 'opcache.enable_cli=1'; \
-    echo 'upload_max_filesize=128M'; \
-    echo 'post_max_size=128M'; \
-    } > /usr/local/etc/php/conf.d/php-recommended.ini
-
-RUN pecl install apcu \
-    && pecl install yaml-2.0.4 \
-    && docker-php-ext-enable apcu yaml
-
-RUN curl -s https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get -y install yarn && \
     rm -rf /var/lib/apt/lists/*
 
-# Set user to www-data
-# RUN chown www-data:www-data /var/www
-USER www-data
+RUN { \
+    echo 'upload_max_filesize=128M'; \
+    echo 'post_max_size=128M'; \
+    } > /usr/local/etc/php/conf.d/php-recommended.ini
 
-# Copy files
-COPY ./ /var/www/html
+# COPY --chown=www-data:www-data ./ /var/www/html
 
-# Return to root user
-USER root
-RUN chown -R www-data:www-data /var/www
-RUN chmod -R 777 /var/www
+# USER www-data
+# WORKDIR /var/www/html
+# RUN composer install && \
+#     yarn install
 
-USER www-data
-WORKDIR /var/www/html
-RUN composer install && \
-    yarn install
-
-USER root
+# USER root
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+ENTRYPOINT [ "/var/www/html/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
+shopt -s extglob
 APACHE_DOCUMENT_ROOT="/var/www/html/public"
 
 sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
 sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+if [ "$CLEAN" = "1" ]; then
+  echo "Doing cleanup of temporary files"
+  rm -rf /var/www/html/data/storage
+  cd /var/www/html/data/viewcache && rm *!(".gitkeep")
+  rm -rf /var/www/html/vendor
+  rm -rf /var/www/html/public/node_modules
+fi
 
 composer install
 yarn install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+APACHE_DOCUMENT_ROOT="/var/www/html/public"
+
+sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
+sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+composer install
+yarn install
+
+usermod -u $DATA_UID www-data
+groupmod -g $DATA_UID www-data
+
+exec ${@:-apache2-foreground}

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DATA_UID=$UID
+CLEAN=
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -u | --uid )      shift       # Override the UID override passed for www-data
+                      DATA_UID=$1
+                      ;;
+    -c | --clean )    shift       # Delete all cache and vendor files
+                      CLEAN=1
+                      ;;
+    * )               usage
+                      exit 1
+  esac
+  shift
+done
 
 docker build -t grocy:dev -f ./Dockerfile.dev .
-docker run -p 8000:80 -v $DIR:/var/www/html -e DATA_UID=$UID grocy:dev
+docker run -p 8000:80 -v $DIR:/var/www/html -e DATA_UID=$DATA_UID -e CLEAN=$CLEAN grocy:dev

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+docker build -t grocy:dev -f ./Dockerfile.dev .
+docker run -p 8000:80 -v $DIR:/var/www/html -e DATA_UID=$UID grocy:dev


### PR DESCRIPTION
With this, the only thing needed to launch a development environment is a working Docker setup and be able to run bash scripts.

Starting the environment is done by running `./start-dev.sh`. All the dependencies will be installed and the project directory will be mounted inside the image.

There are two arguments that can be passed to the script:
- -u | --uid        Specify a different UID to pass to the user www-data in the container (defaults to the current user ID)
- -c | --clean    Delete all cache and vendor files