### PR TITLE
use last Chore-Log when determining the next assigned person

### DIFF
--- a/services/ChoresService.php
+++ b/services/ChoresService.php
@@ -133,7 +133,7 @@ class ChoresService extends BaseService
 
 		$chore = $this->getDatabase()->chores($choreId);
 		$choreLastTrackedTime = $this->getDatabase()->chores_log()->where('chore_id = :1 AND undone = 0', $choreId)->max('tracked_time');
-		$lastChoreLogRow =  $this->getDatabase()->chores_log()->where('chore_id = :1 AND tracked_time = :2 AND undone = 0', $choreId, $choreLastTrackedTime)->fetch();
+		$lastChoreLogRow =  $this->getDatabase()->chores_log()->where('chore_id = :1 AND tracked_time = :2 AND undone = 0', $choreId, $choreLastTrackedTime)->orderBy('row_created_timestamp', 'DESC')->fetch();
 		$lastDoneByUserId = $lastChoreLogRow->done_by_user_id;
 
 		$users = $this->getUsersService()->GetUsersAsDto();


### PR DESCRIPTION
Fixes #930 
I think I found the problem:
When determining the next assigned person for a chore, the last "tracked_time" is used.
If you "Track date only", and multiple users execute the chore at one day, it is "undefined" which of these executions is the last one. It seems to be always the first tracked on that date, so the next assigned person is whoever is after the person who first executed it.
That happens also with more than 2 persons. (and is not related to the alphabetically last person).

I fix this by using the last row_created_timestamp to identify the last execution.


Quick Fix: Uncheck the "Track date only" checkbox.
