### PR TITLE
Run multi instances by making GROCY_DATAPATH customizable

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,7 +10,22 @@ if (file_exists(__DIR__ . '/../embedded.txt'))
 else
 {
 	define('GROCY_IS_EMBEDDED_INSTALL', false);
-	define('GROCY_DATAPATH', __DIR__ . '/../data');
+
+	$datapath = 'data';
+	if (getenv('GROCY_DATAPATH') !== false)
+	{
+		$datapath = getenv('GROCY_DATAPATH');
+	}
+	elseif (array_key_exists('GROCY_DATAPATH', $_SERVER))
+	{
+		$datapath = $_SERVER['GROCY_DATAPATH'];
+	}
+
+	if ($datapath[0] != '/')
+	{
+		$datapath = __DIR__ . '/../' . $datapath;
+	}
+	define('GROCY_DATAPATH', $datapath);
 }
 
 require_once __DIR__ . '/../helpers/PrerequisiteChecker.php';


### PR DESCRIPTION
Hi!

I am running multiple instances of grocy to keep track of different households. To make maintenance easier, I wanted to run all instances from the same installation directory and separate the data directories only. Previously the data directory was fixed to the GROCY_DATAPATH constant. This PR allows overriding the default GROCY_DATAPATH location by the FastCGI parameter `GROCY_DATAPATH`. Relative paths are modified and get rooted at the top level grocy installation directory. The previous behaviour is preserved in case the new parameter is absent.

The following example nginx config snippet shows how to run multiple instances.

```nginx
server {
    location /instance1/ {
        alias /var/www/grocy/;
        set $instance instance1;
        try_files $uri @grocy;
    }

    location /instane2/ {
        alias /var/www/grocy/;
        set $instance instance2;
        try_files $uri @grocy;
    }

    location @grocy {
        fastcgi_pass 127.0.0.1:9000;
        include fastcgi_params;
        fastcgi_param SCRIPT_FILENAME index.php;
        fastcgi_param GROCY_DATAPATH data/$instance;
    }
}
```