### PR TITLE
Change nginx guidance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Just unpack the [latest release](https://releases.grocy.info/latest) on your PHP
 
 Alternatively clone this repository (the `release` branch always references the latest released version, or checkout the latest tagged revision) and install Composer and Yarn dependencies manually.
 
-If you use nginx as your webserver, please include `try_files $uri /index.php$is_args$query_string;` in your location block.
+If you use nginx as your webserver, please include `try_files $uri /index.php;` in your location block.
 
 If, however, your webserver does not support URL rewriting, set `DISABLE_URL_REWRITING` in `data/config.php` (`Setting('DISABLE_URL_REWRITING', true);`).
 


### PR DESCRIPTION
The readme currently advises that nginx users put `try_files $uri
/index.php$is_args$query_string;` in the location block; this doesn't
work (produces 404s) and is also inconsistent with the example nginx
configuration at
https://github.com/grocy/grocy-docker/issues/15#issuecomment-486579894.

This PR changes the README so that it works and is consistent with that
configuration.