### PR TITLE
Fix base path computation when running in subdirectory

### DIFF
--- a/helpers/UrlManager.php
+++ b/helpers/UrlManager.php
@@ -6,14 +6,7 @@ class UrlManager
 {
 	public function __construct(string $basePath)
 	{
-		if ($basePath === '/')
-		{
-			$this->BasePath = $this->GetBaseUrl();
-		}
-		else
-		{
-			$this->BasePath = $basePath;
-		}
+		$this->BasePath = $this->GetBaseUrl() . $basePath;
 	}
 
 	protected $BasePath;


### PR DESCRIPTION
This is my attempt to fix #944. I tested it with a version of grocy running in the web root and a version running in a subdirectory.