### PR TITLE
Stock-Journal: API, Summary, Done By

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -720,6 +720,11 @@ class StockApiController extends BaseApiController
 		return $this->FilteredApiResponse($response, $this->getDatabase()->uihelper_stock_journal(), $request->getQueryParams());
 	}
 
+	public function JournalSummary(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		return $this->FilteredApiResponse($response, $this->getDatabase()->uihelper_stock_journal_summary(), $request->getQueryParams());
+	}
+
 	public function __construct(\DI\Container $container)
 	{
 		parent::__construct($container);

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -715,6 +715,11 @@ class StockApiController extends BaseApiController
 		}
 	}
 
+	public function Journal(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		return $this->FilteredApiResponse($response, $this->getDatabase()->uihelper_stock_journal(), $request->getQueryParams());
+	}
+
 	public function __construct(\DI\Container $container)
 	{
 		parent::__construct($container);

--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -440,4 +440,24 @@ class StockController extends BaseController
 	{
 		parent::__construct($container);
 	}
+
+	public function JournalSummary(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		$entries = $this->getDatabase()->uihelper_stock_journal_summary();
+		if (isset($request->getQueryParams()['product_id']))
+		{
+			$entries = $entries->where('product_id', $request->getQueryParams()['product_id']);
+		}
+		if (isset($request->getQueryParams()['user_id']))
+		{
+			$entries = $entries->where('user_id', $request->getQueryParams()['user_id']);
+		}
+		if (isset($request->getQueryParams()['transaction_type']))
+		{
+			$entries = $entries->where('transaction_type', $request->getQueryParams()['transaction_type']);
+		}
+		return $this->renderPage($response, 'stockjournalsummary', [
+			'entries' => $entries
+		]);
+	}
 }

--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -33,10 +33,8 @@ class StockController extends BaseController
 	public function Journal(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
 		return $this->renderPage($response, 'stockjournal', [
-			'stockLog' => $this->getDatabase()->stock_log()->orderBy('row_created_timestamp', 'DESC'),
-			'locations' => $this->getDatabase()->locations()->orderBy('name'),
+			'stockLog' => $this->getDatabase()->uihelper_stock_journal()->orderBy('row_created_timestamp', 'DESC'),
 			'products' => $this->getDatabase()->products()->where('active = 1')->orderBy('name'),
-			'quantityunits' => $this->getDatabase()->quantity_units()->orderBy('name')
 		]);
 	}
 

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1906,3 +1906,6 @@ msgstr ""
 
 msgid "Journal summary"
 msgstr ""
+
+msgid "Journal summary for this product"
+msgstr ""

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1901,8 +1901,8 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-msgid "Journal-Summary"
+msgid "Stock journal summary"
 msgstr ""
 
-msgid "Stock journal summary"
+msgid "Journal summary"
 msgstr ""

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1900,3 +1900,9 @@ msgstr ""
 
 msgid "Default"
 msgstr ""
+
+msgid "Journal-Summary"
+msgstr ""
+
+msgid "Stock journal summary"
+msgstr ""

--- a/migrations/0115.sql
+++ b/migrations/0115.sql
@@ -1,53 +1,5 @@
-ALTER TABLE stock_log
-    RENAME TO stock_log_old;
-
-CREATE TABLE stock_log(
-    id                          INTEGER        not null        primary key autoincrement unique,
-    product_id                  INTEGER        not null,
-    amount                      DECIMAL(15, 2) not null,
-    best_before_date            DATE,
-    purchased_date              DATE,
-    used_date                   DATE,
-    spoiled                     INTEGER  default 0 not null,
-    stock_id                    TEXT           not null,
-    transaction_type            TEXT           not null,
-    price                       DECIMAL(15, 2),
-    undone                      TINYINT  default 0 not null     CHECK(undone IN (0, 1)),
-    undone_timestamp            DATETIME,
-    opened_date                 DATETIME,
-    row_created_timestamp       DATETIME DEFAULT (datetime('now', 'localtime')),
-    location_id                 INTEGER,
-    recipe_id                   INTEGER,
-    correlation_id              TEXT,
-    transaction_id              TEXT,
-    stock_row_id                INTEGER,
-    shopping_location_id        INTEGER,
-    qu_factor_purchase_to_stock REAL     default 1.0 not null,
-    user_id                     INTEGER        NOT NULL
-                      );
-
-
-INSERT INTO stock_log
-(product_id, amount, best_before_date, purchased_date, used_date, spoiled, stock_id, transaction_type, price, undone,
- undone_timestamp, opened_date, row_created_timestamp, user_id)
-SELECT product_id,
-       amount,
-       best_before_date,
-       purchased_date,
-       used_date,
-       spoiled,
-       stock_id,
-       transaction_type,
-       price,
-       undone,
-       undone_timestamp,
-       opened_date,
-       row_created_timestamp,
-       (SELECT id FROM users WHERE username = 'admin')
-FROM stock_log_old;
-
-DROP TABLE stock_log_old;
-
+ALTER TABLE stock_log ADD COLUMN
+    user_id INTEGER NOT NULL DEFAULT 1;
 
 CREATE VIEW uihelper_stock_journal
 AS

--- a/migrations/0115.sql
+++ b/migrations/0115.sql
@@ -1,0 +1,74 @@
+ALTER TABLE stock_log
+    RENAME TO stock_log_old;
+
+CREATE TABLE stock_log(
+    id                          INTEGER        not null        primary key autoincrement unique,
+    product_id                  INTEGER        not null,
+    amount                      DECIMAL(15, 2) not null,
+    best_before_date            DATE,
+    purchased_date              DATE,
+    used_date                   DATE,
+    spoiled                     INTEGER  default 0 not null,
+    stock_id                    TEXT           not null,
+    transaction_type            TEXT           not null,
+    price                       DECIMAL(15, 2),
+    undone                      TINYINT  default 0 not null     CHECK(undone IN (0, 1)),
+    undone_timestamp            DATETIME,
+    opened_date                 DATETIME,
+    row_created_timestamp       DATETIME DEFAULT (datetime('now', 'localtime')),
+    location_id                 INTEGER,
+    recipe_id                   INTEGER,
+    correlation_id              TEXT,
+    transaction_id              TEXT,
+    stock_row_id                INTEGER,
+    shopping_location_id        INTEGER,
+    qu_factor_purchase_to_stock REAL     default 1.0 not null,
+    user_id                     INTEGER        NOT NULL
+                      );
+
+
+INSERT INTO stock_log
+(product_id, amount, best_before_date, purchased_date, used_date, spoiled, stock_id, transaction_type, price, undone,
+ undone_timestamp, opened_date, row_created_timestamp, user_id)
+SELECT product_id,
+       amount,
+       best_before_date,
+       purchased_date,
+       used_date,
+       spoiled,
+       stock_id,
+       transaction_type,
+       price,
+       undone,
+       undone_timestamp,
+       opened_date,
+       row_created_timestamp,
+       (SELECT id FROM users WHERE username = 'admin')
+FROM stock_log_old;
+
+DROP TABLE stock_log_old;
+
+
+CREATE VIEW uihelper_stock_journal
+AS
+SELECT stock_log.id,
+       stock_log.row_created_timestamp,
+       stock_log.correlation_id,
+       stock_log.undone,
+       stock_log.undone_timestamp,
+       stock_log.row_created_timestamp,
+       stock_log.transaction_type,
+       stock_log.spoiled,
+       stock_log.amount,
+       stock_log.location_id,
+       l.name         AS location_name,
+       p.name         AS product_name,
+       qu.name        AS qu_name,
+       qu.name_plural AS qu_name_plural,
+       u.display_name AS user_display_name
+
+FROM stock_log
+         JOIN users_dto u on stock_log.user_id = u.id
+         JOIN products p on stock_log.product_id = p.id
+         JOIN locations l on p.location_id = l.id
+         JOIN quantity_units qu ON p.qu_id_stock = qu.id;

--- a/migrations/0115.sql
+++ b/migrations/0115.sql
@@ -72,3 +72,18 @@ FROM stock_log
          JOIN products p on stock_log.product_id = p.id
          JOIN locations l on p.location_id = l.id
          JOIN quantity_units qu ON p.qu_id_stock = qu.id;
+
+
+CREATE VIEW uihelper_stock_journal_summary
+AS
+SELECT user_id AS id, -- dummy, LessQL needs an id column
+       user_id, u.display_name AS user_display_name, p.name AS product_name, product_id, transaction_type,
+       qu.name        AS qu_name,
+       qu.name_plural AS qu_name_plural,
+       SUM(amount) AS amount
+FROM stock_log
+    JOIN users_dto u on stock_log.user_id = u.id
+    JOIN products p on stock_log.product_id = p.id
+    JOIN quantity_units qu ON p.qu_id_stock = qu.id
+WHERE undone = 0
+    GROUP BY user_id, product_id,transaction_type;

--- a/public/viewjs/stockjournalsummary.js
+++ b/public/viewjs/stockjournalsummary.js
@@ -1,0 +1,6 @@
+var journalSummaryTable = $('#journal-summary-table').DataTable({
+	'paginate': true,
+	'order': [[0, 'desc']]
+});
+$('#journal-summary-table tbody').removeClass("d-none");
+journalSummaryTable.columns.adjust().draw();

--- a/routes.php
+++ b/routes.php
@@ -203,6 +203,7 @@ $app->group('/api', function (RouteCollectorProxy $group) {
 		$group->post('/stock/transactions/{transactionId}/undo', '\Grocy\Controllers\StockApiController:UndoTransaction');
 		$group->get('/stock/barcodes/external-lookup/{barcode}', '\Grocy\Controllers\StockApiController:ExternalBarcodeLookup');
 		$group->get('/productbarcodedetails/{barcode}', '\Grocy\Controllers\StockApiController:ProductBarcodeDetails');
+		$group->get('/stock/journal', '\Grocy\Controllers\StockApiController:Journal');
 	}
 
 	// Shopping list

--- a/routes.php
+++ b/routes.php
@@ -57,6 +57,7 @@ $app->group('', function (RouteCollectorProxy $group) {
 		$group->get('/stockjournal', '\Grocy\Controllers\StockController:Journal');
 		$group->get('/locationcontentsheet', '\Grocy\Controllers\StockController:LocationContentSheet');
 		$group->get('/quantityunitpluraltesting', '\Grocy\Controllers\StockController:QuantityUnitPluralFormTesting');
+		$group->get('/stockjournal/summary', '\Grocy\Controllers\StockController:JournalSummary');
 	}
 
 	// Stock price tracking
@@ -204,6 +205,7 @@ $app->group('/api', function (RouteCollectorProxy $group) {
 		$group->get('/stock/barcodes/external-lookup/{barcode}', '\Grocy\Controllers\StockApiController:ExternalBarcodeLookup');
 		$group->get('/productbarcodedetails/{barcode}', '\Grocy\Controllers\StockApiController:ProductBarcodeDetails');
 		$group->get('/stock/journal', '\Grocy\Controllers\StockApiController:Journal');
+		$group->get('/stock/journal/summary', '\Grocy\Controllers\StockApiController:JournalSummary');
 	}
 
 	// Shopping list

--- a/services/StockService.php
+++ b/services/StockService.php
@@ -112,7 +112,8 @@ class StockService extends BaseService
 				'location_id' => $locationId,
 				'transaction_id' => $transactionId,
 				'shopping_location_id' => $shoppingLocationId,
-				'qu_factor_purchase_to_stock' => $quFactorPurchaseToStock
+				'qu_factor_purchase_to_stock' => $quFactorPurchaseToStock,
+				'user_id' => GROCY_USER_ID
 			]);
 			$logRow->save();
 
@@ -259,7 +260,8 @@ class StockService extends BaseService
 						'price' => $stockEntry->price,
 						'opened_date' => $stockEntry->opened_date,
 						'recipe_id' => $recipeId,
-						'transaction_id' => $transactionId
+						'transaction_id' => $transactionId,
+						'user_id' => GROCY_USER_ID
 					]);
 					$logRow->save();
 
@@ -283,7 +285,8 @@ class StockService extends BaseService
 						'price' => $stockEntry->price,
 						'opened_date' => $stockEntry->opened_date,
 						'recipe_id' => $recipeId,
-						'transaction_id' => $transactionId
+						'transaction_id' => $transactionId,
+						'user_id' => GROCY_USER_ID
 					]);
 					$logRow->save();
 
@@ -328,7 +331,8 @@ class StockService extends BaseService
 			'qu_factor_purchase_to_stock' => $stockRow->qu_factor_purchase_to_stock,
 			'correlation_id' => $correlationId,
 			'transaction_id' => $transactionId,
-			'stock_row_id' => $stockRow->id
+			'stock_row_id' => $stockRow->id,
+			'user_id' => GROCY_USER_ID
 		]);
 		$logOldRowForStockUpdate->save();
 
@@ -369,7 +373,8 @@ class StockService extends BaseService
 			'qu_factor_purchase_to_stock' => $stockRow->qu_factor_purchase_to_stock,
 			'correlation_id' => $correlationId,
 			'transaction_id' => $transactionId,
-			'stock_row_id' => $stockRow->id
+			'stock_row_id' => $stockRow->id,
+			'user_id' => GROCY_USER_ID
 		]);
 		$logNewRowForStockUpdate->save();
 
@@ -738,7 +743,8 @@ class StockService extends BaseService
 					'transaction_type' => self::TRANSACTION_TYPE_PRODUCT_OPENED,
 					'price' => $stockEntry->price,
 					'opened_date' => date('Y-m-d'),
-					'transaction_id' => $transactionId
+					'transaction_id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRow->save();
 
@@ -777,7 +783,8 @@ class StockService extends BaseService
 					'transaction_type' => self::TRANSACTION_TYPE_PRODUCT_OPENED,
 					'price' => $stockEntry->price,
 					'opened_date' => date('Y-m-d'),
-					'transaction_id' => $transactionId
+					'transaction_id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRow->save();
 
@@ -914,7 +921,8 @@ class StockService extends BaseService
 					'opened_date' => $stockEntry->opened_date,
 					'location_id' => $stockEntry->location_id,
 					'correlation_id' => $correlationId,
-					'transaction_Id' => $transactionId
+					'transaction_Id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRowForLocationFrom->save();
 
@@ -930,7 +938,8 @@ class StockService extends BaseService
 					'opened_date' => $stockEntry->opened_date,
 					'location_id' => $locationIdTo,
 					'correlation_id' => $correlationId,
-					'transaction_Id' => $transactionId
+					'transaction_Id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRowForLocationTo->save();
 
@@ -957,7 +966,8 @@ class StockService extends BaseService
 					'opened_date' => $stockEntry->opened_date,
 					'location_id' => $stockEntry->location_id,
 					'correlation_id' => $correlationId,
-					'transaction_Id' => $transactionId
+					'transaction_Id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRowForLocationFrom->save();
 
@@ -973,7 +983,8 @@ class StockService extends BaseService
 					'opened_date' => $stockEntry->opened_date,
 					'location_id' => $locationIdTo,
 					'correlation_id' => $correlationId,
-					'transaction_Id' => $transactionId
+					'transaction_Id' => $transactionId,
+					'user_id' => GROCY_USER_ID
 				]);
 				$logRowForLocationTo->save();
 

--- a/views/stockjournal.blade.php
+++ b/views/stockjournal.blade.php
@@ -5,12 +5,15 @@
 @section('viewJsName', 'stockjournal')
 
 @section('content')
-<div class="row">
-	<div class="col">
-		<h2 class="title">@yield('title')</h2>
+<div class="title-related-links">
+	<h2 class="title">@yield('title')</h2>
+	<div class="related-links">
+		<a class="btn btn-outline-dark responsive-button"
+			href="{{ $U('/stockjournal/summary') }}">
+			{{ $__t('Journal summary') }}
+		</a>
 	</div>
 </div>
-
 <hr>
 <div class="row my-3">
 	<div class="col-xs-12 col-md-6 col-xl-3">

--- a/views/stockjournal.blade.php
+++ b/views/stockjournal.blade.php
@@ -52,6 +52,7 @@
 					<th>{{ $__t('Booking time') }}</th>
 					<th>{{ $__t('Booking type') }}</th>
 					<th class="@if(!GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING) d-none @endif">{{ $__t('Location') }}</th>
+					<th>{{ $__t('Done by') }}</th>
 				</tr>
 			</thead>
 			<tbody class="d-none">
@@ -70,7 +71,7 @@
 						</a>
 					</td>
 					<td>
-						<span class="name-anchor @if($stockLogEntry->undone == 1) text-strike-through @endif">{{ FindObjectInArrayByPropertyValue($products, 'id', $stockLogEntry->product_id)->name }}</span>
+						<span class="name-anchor @if($stockLogEntry->undone == 1) text-strike-through @endif">{{ $stockLogEntry->product_name }}</span>
 						@if($stockLogEntry->undone == 1)
 						<br>
 						{{ $__t('Undone on') . ' ' . $stockLogEntry->undone_timestamp }}
@@ -79,7 +80,7 @@
 						@endif
 					</td>
 					<td>
-						<span class="locale-number locale-number-quantity-amount">{{ $stockLogEntry->amount }}</span> {{ $__n($stockLogEntry->amount, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $stockLogEntry->product_id)->qu_id_stock)->name, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $stockLogEntry->product_id)->qu_id_stock)->name_plural) }}
+						<span class="locale-number locale-number-quantity-amount">{{ $stockLogEntry->amount }}</span> {{ $__n($stockLogEntry->amount, $stockLogEntry->qu_name, $stockLogEntry->qu_name_plural) }}
 					</td>
 					<td>
 						{{ $stockLogEntry->row_created_timestamp }}
@@ -93,7 +94,10 @@
 						@endif
 					</td>
 					<td class="@if(!GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING) d-none @endif">
-						{{ FindObjectInArrayByPropertyValue($locations, 'id', $stockLogEntry->location_id)->name }}
+						{{ $stockLogEntry->location_name }}
+					</td>
+					<td>
+						{{ $stockLogEntry->user_display_name }}
 					</td>
 				</tr>
 				@endforeach

--- a/views/stockjournalsummary.blade.php
+++ b/views/stockjournalsummary.blade.php
@@ -1,0 +1,47 @@
+@extends('layout.default')
+
+@section('title', $__t('Stock journal summary'))
+@section('activeNav', '')
+@section('viewJsName', 'stockjournalsummary')
+
+@section('content')
+	<div class="row">
+		<div class="col">
+			<h2 class="title">@yield('title')</h2>
+		</div>
+	</div>
+	<hr>
+	<div class="row">
+		<div class="col">
+			<table id="journal-summary-table"
+				   class="table table-sm table-striped dt-responsive">
+				<thead>
+				<tr>
+					<th>{{ $__t('Product') }}</th>
+					<th>{{ $__t('Booking type') }}</th>
+					<th>{{ $__t('User') }}</th>
+					<th>{{ $__t('Amount') }}</th>
+				</tr>
+				</thead>
+				<tbody class="d-none">
+				@foreach($entries as $journalEntry)
+					<tr>
+						<td>
+							{{ $journalEntry->product_name }}
+						</td>
+						<td>
+							{{ $__t($journalEntry->transaction_type) }}
+						</td>
+						<td>
+							{{ $journalEntry->user_display_name }}
+						</td>
+						<td>
+							<span class="locale-number locale-number-quantity-amount">{{ $journalEntry->amount }}</span> {{ $__n($journalEntry->amount, $journalEntry->qu_name, $journalEntry->qu_name_plural) }}
+						</td>
+					</tr>
+				@endforeach
+				</tbody>
+			</table>
+		</div>
+	</div>
+@stop

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -20,10 +20,6 @@
 			<h2 class="title">@yield('title')</h2>
 			<div class="related-links">
 				<a class="btn btn-outline-dark responsive-button"
-				   href="{{ $U('/stockjournal/summary') }}">
-					{{ $__t('Stock journal summary') }}
-				</a>
-				<a class="btn btn-outline-dark responsive-button"
 					href="{{ $U('/stockjournal') }}">
 					{{ $__t('Journal') }}
 				</a>
@@ -146,7 +142,9 @@
 			<tbody class="d-none">
 				@foreach($currentStock as $currentStockEntry)
 				<tr id="product-{{ $currentStockEntry->product_id }}-row"
-					class="@if(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime('-1 days')) && $currentStockEntry->amount > 0) table-danger @elseif(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime("+$nextXDays days"))
+					class="@if(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime('-1 days')) && $currentStockEntry->amount > 0) table-danger @elseif(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime("
+					+$nextXDays
+					days"))
 					&&
 					$currentStockEntry->amount > 0) table-warning @elseif ($currentStockEntry->product_missing) table-info @endif">
 					<td class="fit-content border-right">
@@ -273,9 +271,9 @@
 								</a>
 								@endif
 								<a class="dropdown-item"
-								   type="button"
-								   href="{{ $U('/stockjournal/summary?product_id=') }}{{ $currentStockEntry->product_id }}">
-									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Journal-Summary') }}</span>
+									type="button"
+									href="{{ $U('/stockjournal/summary?product_id=') }}{{ $currentStockEntry->product_id }}">
+									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Journal summary') }}</span>
 								</a>
 							</div>
 						</div>
@@ -331,7 +329,8 @@
 							&&
 							$currentStockEntry->amount > 0) expired @elseif($currentStockEntry->best_before_date < date('Y-m-d
 								23:59:59',
-								strtotime("+$nextXDays days"))
+								strtotime("+$nextXDays
+								days"))
 								&&
 								$currentStockEntry->amount > 0) expiring @endif @if($currentStockEntry->product_missing) belowminstockamount @endif
 					</td>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -20,6 +20,10 @@
 			<h2 class="title">@yield('title')</h2>
 			<div class="related-links">
 				<a class="btn btn-outline-dark responsive-button"
+				   href="{{ $U('/stockjournal/summary') }}">
+					{{ $__t('Stock journal summary') }}
+				</a>
+				<a class="btn btn-outline-dark responsive-button"
 					href="{{ $U('/stockjournal') }}">
 					{{ $__t('Journal') }}
 				</a>
@@ -268,6 +272,11 @@
 									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Search for recipes containing this product') }}</span>
 								</a>
 								@endif
+								<a class="dropdown-item"
+								   type="button"
+								   href="{{ $U('/stockjournal/summary?product_id=') }}{{ $currentStockEntry->product_id }}">
+									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Journal-Summary') }}</span>
+								</a>
 							</div>
 						</div>
 					</td>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -248,6 +248,11 @@
 									href="{{ $U('/stockjournal?product=') }}{{ $currentStockEntry->product_id }}">
 									<span class="dropdown-item-icon"><i class="fas fa-file-alt"></i></span> <span class="dropdown-item-text">{{ $__t('Stock journal for this product') }}</span>
 								</a>
+								<a class="dropdown-item"
+									type="button"
+									href="{{ $U('/stockjournal/summary?product_id=') }}{{ $currentStockEntry->product_id }}">
+									<span class="dropdown-item-icon"><i class="fas fa-file-archive"></i></span> <span class="dropdown-item-text">{{ $__t('Journal summary for this product') }}</span>
+								</a>
 								<a class="dropdown-item permission-MASTER_DATA_EDIT"
 									type="button"
 									href="{{ $U('/product/') }}{{ $currentStockEntry->product_id . '?returnto=%2Fstockoverview' }}">
@@ -270,11 +275,6 @@
 									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Search for recipes containing this product') }}</span>
 								</a>
 								@endif
-								<a class="dropdown-item"
-									type="button"
-									href="{{ $U('/stockjournal/summary?product_id=') }}{{ $currentStockEntry->product_id }}">
-									<span class="dropdown-item-icon"><i class="fas fa-cocktail"></i></span> <span class="dropdown-item-text">{{ $__t('Journal summary') }}</span>
-								</a>
 							</div>
 						</div>
 					</td>


### PR DESCRIPTION
Fixes #827 , #963 , #949 

I've implemented an API for the stock journal, available at `/api/stock/journal`.

For #827 and #949, I added the user to stock_log. The default for the migrations is 'admin'.

I also added a new Page (and API) "stock journal summary", which sums up the amounts grouped by product, user and transaction-type.