### PR TITLE
Adds a few small frontend fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,6 @@ Just overwrite everything with the latest release while keeping the `data` direc
 
 If you run grocy on Linux, there is also `update.sh` (remember to make the script executable (`chmod +x update.sh`) and ensure that you have `unzip` installed) which does exactly this and additionally creates a backup (`.tgz` archive) of the current installation in `data/backups` (backups older than 60 days will be deleted during the update).
 
-## How to bootstrap a development environment
-
-Initialize:
-
-```
-$ npm install
-$ composer install
-$ cp config-dist.php data/config.php
-```
-
-Start the webserver:
-
-```
-$ cd public/
-$ ln -sf ../node_modules node_modules
-$ env GROCY_DATAPATH=$(pwd)/../data php -S localhost:3000
-```
-
 ## Localization
 grocy is fully localizable - the default language is English (integrated into code), a German localization is always maintained by me.
 You can easily help translating grocy at https://www.transifex.com/grocy/grocy, if your language is incomplete or not available yet.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ Just overwrite everything with the latest release while keeping the `data` direc
 
 If you run grocy on Linux, there is also `update.sh` (remember to make the script executable (`chmod +x update.sh`) and ensure that you have `unzip` installed) which does exactly this and additionally creates a backup (`.tgz` archive) of the current installation in `data/backups` (backups older than 60 days will be deleted during the update).
 
+## How to bootstrap a development environment
+
+Initialize:
+
+```
+$ npm install
+$ composer install
+$ cp config-dist.php data/config.php
+```
+
+Start the webserver:
+
+```
+$ cd public/
+$ ln -sf ../node_modules node_modules
+$ env GROCY_DATAPATH=$(pwd)/../data php -S localhost:3000
+```
+
 ## Localization
 grocy is fully localizable - the default language is English (integrated into code), a German localization is always maintained by me.
 You can easily help translating grocy at https://www.transifex.com/grocy/grocy, if your language is incomplete or not available yet.

--- a/public/js/grocy_clock.js
+++ b/public/js/grocy_clock.js
@@ -1,4 +1,4 @@
-﻿$("#show-clock-in-header").on("change", function()
+﻿$(document).on("change", "#show-clock-in-header", function()
 {
 	CheckHeaderClockEnabled();
 });

--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -411,6 +411,11 @@ Grocy.FrontendHelpers.ValidateForm('product-form');
 $("#allow_partial_units_in_stock").click();
 $("#allow_partial_units_in_stock").click();
 
+$(document).on('click', '#save-product-button-continue', function () {
+	Grocy.ProductEditFormRedirectUri = "reload";
+	$('#save-product-button').click();
+});
+
 $(document).on('click', '.qu-conversion-delete-button', function(e)
 {
 	var objectId = $(e.currentTarget).attr('data-qu-conversion-id');

--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -342,6 +342,12 @@ $("#allow_partial_units_in_stock").on("click", function()
 	Grocy.FrontendHelpers.ValidateForm("product-form");
 });
 
+$('#product-picture').change(function () {
+	if ($(this).val()) {
+		Grocy.DeleteProductPictureOnSave = false;
+	}
+});
+
 Grocy.DeleteProductPictureOnSave = false;
 $('#delete-current-product-picture-button').on('click', function(e)
 {

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -372,9 +372,9 @@
 			))
 
 			<button id="save-product-button-continue"
-				class="save-recipe btn btn-success mb-2">{{ $__t('Save & continue') }}</button>
+				class="btn btn-success mb-2">{{ $__t('Save & continue') }}</button>
 			<button id="save-product-button"
-				class="save-recipe btn btn-info mb-2">{{ $__t('Save') }}</button>
+				class="btn btn-info mb-2">{{ $__t('Save') }}</button>
 		</form>
 
 	</div>

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -371,8 +371,10 @@
 			'entity' => 'products'
 			))
 
+			<button id="save-product-button-continue"
+				class="save-recipe btn btn-success mb-2">{{ $__t('Save & continue') }}</button>
 			<button id="save-product-button"
-				class="btn btn-success">{{ $__t('Save') }}</button>
+				class="save-recipe btn btn-info mb-2">{{ $__t('Save') }}</button>
 		</form>
 
 	</div>


### PR DESCRIPTION
Detailed descriptions can be found in the corresponding commit messages. To summarize, the following things changed with this PR:

* 6ffad1d  adds instructions how to bootstrap a dev environment
* 2b0208e  fixes the checkbox-behavior for enabling/disabling the header clock
* 007b427: Make sure it's possible to delete and update a product's picture in one go.
* 248852b: Add a `Save & continue` button to product form.