### PR TITLE
Some bug fixes.

### DIFF
--- a/controllers/GenericEntityApiController.php
+++ b/controllers/GenericEntityApiController.php
@@ -64,7 +64,7 @@ class GenericEntityApiController extends BaseApiController
 		}
 		else
 		{
-			return $this->GenericErrorResponse($response, $ex->getMessage());
+			return $this->GenericErrorResponse($response, "Invalid entity");
 		}
 	}
 

--- a/public/js/grocy.js
+++ b/public/js/grocy.js
@@ -696,3 +696,10 @@ $(document).on("click", "a.btn.link-return", function(e)
 		location.href = U(link);
 	}
 });
+
+$('.dropdown-item').has('.form-check input[type=checkbox]').on('click', function (e) {
+	if($(e.target).is('div.form-check') || $(e.target).is('div.dropdown-item'))
+	{
+		$(e.target).find('input[type=checkbox]').click();
+	}
+})

--- a/public/js/grocy_nightmode.js
+++ b/public/js/grocy_nightmode.js
@@ -3,11 +3,11 @@
 	var value = $(this).is(":checked");
 	if (value)
 	{
-		$("body").addClass("night-mode");
-
 		// Force disable auto night mode when night mode is enabled
 		$("#auto-night-mode-enabled").prop("checked", false);
 		$("#auto-night-mode-enabled").trigger("change");
+
+		$("body").addClass("night-mode");
 	}
 	else
 	{

--- a/public/viewjs/components/datetimepicker.js
+++ b/public/viewjs/components/datetimepicker.js
@@ -12,9 +12,6 @@ Grocy.Components.DateTimePicker.GetValue = function()
 
 Grocy.Components.DateTimePicker.SetValue = function(value)
 {
-	Grocy.Components.DateTimePicker.GetInputElement().val(value);
-	Grocy.Components.DateTimePicker.GetInputElement().trigger('change');
-
 	// "Click" the shortcut checkbox when the desired value is
 	// not the shortcut value and it is currently set
 	var shortcutValue = $("#datetimepicker-shortcut").data("datetimepicker-shortcut-value");
@@ -22,6 +19,8 @@ Grocy.Components.DateTimePicker.SetValue = function(value)
 	{
 		$("#datetimepicker-shortcut").click();
 	}
+	Grocy.Components.DateTimePicker.GetInputElement().val(value);
+	Grocy.Components.DateTimePicker.GetInputElement().trigger('change');
 
 	Grocy.Components.DateTimePicker.GetInputElement().keyup();
 }

--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -29,7 +29,14 @@
 
 			var jsonData = {};
 			jsonData.amount = amount;
-			jsonData.best_before_date = Grocy.Components.DateTimePicker.GetValue();
+			if (Grocy.Components.DateTimePicker)
+			{
+				jsonData.best_before_date = Grocy.Components.DateTimePicker.GetValue();
+			}
+			else {
+				jsonData.best_before_date = null;
+			}
+
 			if (Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_PRICE_TRACKING)
 			{
 				jsonData.shopping_location_id = Grocy.Components.ShoppingLocationPicker.GetValue();
@@ -99,7 +106,10 @@
 						{
 							Grocy.Components.LocationPicker.Clear();
 						}
-						Grocy.Components.DateTimePicker.Clear();
+						if(Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
+						{
+							Grocy.Components.DateTimePicker.Clear();
+						}
 						Grocy.Components.ProductPicker.SetValue('');
 						if (Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_PRICE_TRACKING)
 						{
@@ -265,23 +275,21 @@ if (Grocy.Components.ProductPicker !== undefined)
 						$("#tare-weight-handling-info").addClass("d-none");
 					}
 
-					if (!Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
+					if (Grocy.FeatureFlags.GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
 					{
-						Grocy.Components.DateTimePicker.SetValue('2999-12-31');
-					}
-
-					if (productDetails.product.default_best_before_days.toString() !== '0')
-					{
-						if (productDetails.product.default_best_before_days == -1)
+						if (productDetails.product.default_best_before_days.toString() !== '0')
 						{
-							if (!$("#datetimepicker-shortcut").is(":checked"))
+							if (productDetails.product.default_best_before_days == -1)
 							{
-								$("#datetimepicker-shortcut").click();
+								if (!$("#datetimepicker-shortcut").is(":checked"))
+								{
+									$("#datetimepicker-shortcut").click();
+								}
 							}
-						}
-						else
-						{
-							Grocy.Components.DateTimePicker.SetValue(moment().add(productDetails.product.default_best_before_days, 'days').format('YYYY-MM-DD'));
+							else
+							{
+								Grocy.Components.DateTimePicker.SetValue(moment().add(productDetails.product.default_best_before_days, 'days').format('YYYY-MM-DD'));
+							}
 						}
 					}
 

--- a/services/CalendarService.php
+++ b/services/CalendarService.php
@@ -95,6 +95,8 @@ class CalendarService extends BaseService
 		}
 
 		$mealPlanRecipeEvents = [];
+		$mealPlanNotesEvents = [];
+		$mealPlanProductEvents = [];
 
 		if (GROCY_FEATURE_FLAG_RECIPES)
 		{
@@ -120,7 +122,7 @@ class CalendarService extends BaseService
 
 			$mealPlanDayNotes = $this->getDatabase()->meal_plan()->where('type', 'note');
 			$titlePrefix = $this->getLocalizationService()->__t('Meal plan note') . ': ';
-			$mealPlanNotesEvents = [];
+
 
 			foreach ($mealPlanDayNotes as $mealPlanDayNote)
 			{
@@ -134,7 +136,7 @@ class CalendarService extends BaseService
 			$products = $this->getDatabase()->products();
 			$mealPlanDayProducts = $this->getDatabase()->meal_plan()->where('type', 'product');
 			$titlePrefix = $this->getLocalizationService()->__t('Meal plan product') . ': ';
-			$mealPlanProductEvents = [];
+
 
 			foreach ($mealPlanDayProducts as $mealPlanDayProduct)
 			{

--- a/views/components/locationpicker.blade.php
+++ b/views/components/locationpicker.blade.php
@@ -8,10 +8,10 @@
 @php if(empty($hint)) { $hint = ''; } @endphp
 
 <div class="form-group"
-	data-next-input-selector="{{ $nextInputSelector }}"
+	@if(isset($nextInputSelector))data-next-input-selector="{{ $nextInputSelector }}" @endif
 	data-prefill-by-name="{{ $prefillByName }}"
 	data-prefill-by-id="{{ $prefillById }}">
-	<label for="location_id">{{ $__t('Location') }}&nbsp;&nbsp;<span id="{{ $hintId }}"
+	<label for="location_id">{{ $__t('Location') }}&nbsp;&nbsp;<span @if(!empty($hintId))id="{{ $hintId }}" @endif
 			class="small text-muted">{{ $hint }}</span></label>
 	<select class="form-control location-combobox"
 		id="location_id"

--- a/views/components/productpicker.blade.php
+++ b/views/components/productpicker.blade.php
@@ -35,7 +35,12 @@
 		data-target="@productpicker">
 		<option value=""></option>
 		@foreach($products as $product)
-		<option data-additional-searchdata="{{ FindObjectInArrayByPropertyValue($barcodes, 'product_id', $product->id)->barcodes }},"
+			@php $bc = null;
+				if(isset($barcodes)) {
+					$bc = FindObjectInArrayByPropertyValue($barcodes, 'product_id', $product->id);
+				}
+			@endphp
+		<option data-additional-searchdata="@if(isset($bc)){{ $bc->barcodes }}@endif,"
 			value="{{ $product->id }}">{{ $product->name }}</option>
 		@endforeach
 	</select>

--- a/views/components/shoppinglocationpicker.blade.php
+++ b/views/components/shoppinglocationpicker.blade.php
@@ -12,7 +12,7 @@
 	data-next-input-selector="{{ $nextInputSelector }}"
 	data-prefill-by-name="{{ $prefillByName }}"
 	data-prefill-by-id="{{ $prefillById }}">
-	<label for="shopping_location_id">{{ $__t($label) }}&nbsp;&nbsp;<span id="{{ $hintId }}"
+	<label for="shopping_location_id">{{ $__t($label) }}&nbsp;&nbsp;<span @if(!empty($hintId))id="{{ $hintId }}" @endif
 			class="small text-muted">{{ $hint }}</span></label>
 	<select class="form-control shopping-location-combobox"
 		id="shopping_location_id"

--- a/views/purchase.blade.php
+++ b/views/purchase.blade.php
@@ -53,13 +53,7 @@
 				class="text-info font-italic d-none">' . $__t('Tare weight handling enabled - please weigh the whole container, the amount to be posted will be automatically calculcated') . '</div>'
 			))
 
-			@php
-			$additionalGroupCssClasses = '';
-			if (!GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
-			{
-			$additionalGroupCssClasses = 'd-none';
-			}
-			@endphp
+			@if(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
 			@include('components.datetimepicker', array(
 			'id' => 'best_before_date',
 			'label' => 'Best before',
@@ -77,7 +71,7 @@
 			'additionalGroupCssClasses' => $additionalGroupCssClasses,
 			'activateNumberPad' => GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_FIELD_NUMBER_PAD
 			))
-			@php $additionalGroupCssClasses = ''; @endphp
+			@endif
 
 			@if(GROCY_FEATURE_FLAG_STOCK_PRICE_TRACKING)
 			@include('components.numberpicker', array(


### PR DESCRIPTION
- 515da5d The datetimepicker is now removed if FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING is not set (fixes #997)
- 9f9acb7 `DateTimePicker.SetValue()` did not set the value if the shortcut-checkbox was checked (e.g. "Never expires") - it only cleared the field and the checkbox (caused #997: without FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING, the field is set to "Never Expires". When you choose a product with default-best-before-date, the field is cleared/empty and hidden, and the validation failed.)

- ef2e5dd Clicking the whole (highlighted) area in drop downs with checkboxes now toggles the checkbox.
- 50ee248 Night-mode enabling does not need a reload
- Some undefined variables