### PR TITLE
add purchased date to purchase

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -114,6 +114,7 @@ DefaultUserSetting('stock_default_consume_amount', 1);
 DefaultUserSetting('scan_mode_consume_enabled', false);
 DefaultUserSetting('scan_mode_purchase_enabled', false);
 DefaultUserSetting('show_icon_on_stock_overview_page_when_product_is_on_shopping_list', true);
+DefaultUserSetting('product_display_purchased_date', false);
 
 # Shopping list settings
 DefaultUserSetting('shopping_list_to_stock_workflow_auto_submit_when_prefilled', false); // Automatically do the booking using the last price and the amount of the shopping list item, if the product has "Default best before days" set

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -80,6 +80,13 @@ class StockApiController extends BaseApiController
 				$bestBeforeDate = $requestBody['best_before_date'];
 			}
 
+			$purchasedDate = date('Y-m-d');
+
+			if (array_key_exists('purchased_date', $requestBody) && IsIsoDate($requestBody['purchased_date']))
+			{
+				$purchasedDate = $requestBody['purchased_date'];
+			}
+
 			$price = null;
 
 			if (array_key_exists('price', $requestBody) && is_numeric($requestBody['price']))
@@ -115,7 +122,7 @@ class StockApiController extends BaseApiController
 				$transactionType = $requestBody['transactiontype'];
 			}
 
-			$bookingId = $this->getStockService()->AddProduct($args['productId'], $requestBody['amount'], $bestBeforeDate, $transactionType, date('Y-m-d'), $price, $quFactorPurchaseToStock, $locationId, $shoppingLocationId);
+			$bookingId = $this->getStockService()->AddProduct($args['productId'], $requestBody['amount'], $bestBeforeDate, $transactionType, $purchasedDate, $price, $quFactorPurchaseToStock, $locationId, $shoppingLocationId);
 			return $this->ApiResponse($response, $this->getDatabase()->stock_log($bookingId));
 		}
 		catch (\Exception $ex)

--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -29,6 +29,7 @@
 
 			var jsonData = {};
 			jsonData.amount = amount;
+			jsonData.purchased_date = Grocy.Components.DateTimePicker2.GetValue();
 			if (Grocy.Components.DateTimePicker)
 			{
 				jsonData.best_before_date = Grocy.Components.DateTimePicker.GetValue();

--- a/public/viewjs/stocksettings.js
+++ b/public/viewjs/stocksettings.js
@@ -9,3 +9,7 @@ if (BoolVal(Grocy.UserSettings.show_icon_on_stock_overview_page_when_product_is_
 {
 	$("#show_icon_on_stock_overview_page_when_product_is_on_shopping_list").prop("checked", true);
 }
+if (BoolVal(Grocy.UserSettings.product_display_purchased_date))
+{
+	$("#product_display_purchased_date").prop("checked", true);
+}

--- a/views/purchase.blade.php
+++ b/views/purchase.blade.php
@@ -53,6 +53,24 @@
 				class="text-info font-italic d-none">' . $__t('Tare weight handling enabled - please weigh the whole container, the amount to be posted will be automatically calculcated') . '</div>'
 			))
 
+			@if(boolval($userSettings['product_display_purchased_date']))
+			@include('components.datetimepicker2', array(
+			'id' => 'purchased_date',
+			'label' => 'Purchased date',
+			'format' => 'YYYY-MM-DD',
+			'initWithNow' => true,
+			'limitEndToNow' => false,
+			'limitStartToNow' => false,
+			'invalidFeedback' => $__t('A purchase date is required'),
+			'nextInputSelector' => '#best_before_date',
+			'additionalCssClasses' => 'date-only-datetimepicker2',
+			'earlierThanInfoLimit' => date('Y-m-d'),
+			'earlierThanInfoText' => $__t('The given date is earlier than today, are you sure?'),
+			'additionalGroupCssClasses' => $additionalGroupCssClasses,
+			'activateNumberPad' => GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_FIELD_NUMBER_PAD
+			))
+			@endif
+
 			@if(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING)
 			@include('components.datetimepicker', array(
 			'id' => 'best_before_date',

--- a/views/stocksettings.blade.php
+++ b/views/stocksettings.blade.php
@@ -94,6 +94,14 @@
 						data-setting-key="show_icon_on_stock_overview_page_when_product_is_on_shopping_list"> {{ $__t('Show an icon if the product is already on the shopping list') }}
 				</label>
 			</div>
+			<div class="checkbox">
+				<label for="product_display_purchased_date">
+					<input type="checkbox"
+						class="user-setting-control"
+						id="product_display_purchased_date"
+						data-setting-key="product_display_purchased_date"> {{ $__t('Show purchased date on product purchase form to allow editing from default todays date') }}
+				</label>
+			</div>
 		</div>
 
 		<a href="{{ $U('/stockoverview') }}"


### PR DESCRIPTION
feature #888

Initial feature request checkin
I did not limit this to GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING but perhaps it should be?

This might be made a little better by updating the best before date whenever the purchase date is changed?