### PR TITLE
Fixes #1092: Repair QR-Codes for API-Keys

### DIFF
--- a/public/viewjs/manageapikeys.js
+++ b/public/viewjs/manageapikeys.js
@@ -63,7 +63,7 @@ $(document).on('click', '.apikey-delete-button', function(e)
 });
 $('.apikey-show-qr-button').on('click', function()
 {
-	var qrcodeHtml = getQRCodeForAPIKey($(this).data('apikey-key'), $(this).data('apikey-type'));
+	var qrcodeHtml = getQRCodeForAPIKey($(this).data('apikey-type'), $(this).data('apikey-key'));
 	bootbox.alert({
 		title: __t('API key'),
 		message: "<p class='text-center'>" + qrcodeHtml + "</p>",


### PR DESCRIPTION
> Hi, I just saw that API keys are now scannable with QR codes. Thanks for that!
I tried it on the prerelease demo and I noticed that the QR codes don't contain the API key but the instance URL and key type... Is this intended behaviour?

No.
There were two parameters swapped.
The urls should contain the instance URL and the Key, seperated by a `|`.

I refactored the Code before #986 and it seems that I didn't test enough (I think I only checked that there is a QR-Code).
Sorry.

Fixes #1092 