### PR TITLE
AddProduct Method Fix For SelfProduction

### DIFF
--- a/services/StockService.php
+++ b/services/StockService.php
@@ -79,7 +79,7 @@ class StockService extends BaseService
 		}
 	}
 
-	public function AddProduct(int $productId, float $amount, $bestBeforeDate, $transactionType, $purchasedDate, $price, $quFactorPurchaseToStock, $locationId = null, $shoppingLocationId = null, &$transactionId = null)
+	public function AddProduct(int $productId, float $amount, $bestBeforeDate, $transactionType, $purchasedDate, $price, $quFactorPurchaseToStock = null, $locationId = null, $shoppingLocationId = null, &$transactionId = null)
 	{
 		if (!$this->ProductExists($productId))
 		{


### PR DESCRIPTION
When testing a recipe that produces a product, the new quFactorPurchaseToStock provided an error and just needs to be set to null in the AddProduct method. This allows the self producing product to use the default quFactorPurchaseToStock when a recipe is consumed.