### PR TITLE
limit to normal recipes

### DIFF
--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -2,6 +2,8 @@
 
 namespace Grocy\Controllers;
 
+use Grocy\Services\RecipesService;
+
 class StockController extends BaseController
 {
 	public function Consume(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
@@ -12,7 +14,7 @@ class StockController extends BaseController
 		return $this->renderPage($response, 'consume', [
 			'products' => $this->getDatabase()->products()->where('active = 1')->orderBy('name'),
 			'barcodes' => $productBarcodes,
-			'recipes' => $this->getDatabase()->recipes()->orderBy('name'),
+			'recipes' => $this->getDatabase()->recipes()->where('type', RecipesService::RECIPE_TYPE_NORMAL)->orderBy('name'),
 			'locations' => $this->getDatabase()->locations()->orderBy('name')
 		]);
 	}
@@ -431,7 +433,6 @@ class StockController extends BaseController
 		return $this->renderPage($response, 'transfer', [
 			'products' => $this->getDatabase()->products()->where('active = 1')->orderBy('name'),
 			'barcodes' => $productBarcodes,
-			'recipes' => $this->getDatabase()->recipes()->orderBy('name'),
 			'locations' => $this->getDatabase()->locations()->orderBy('name')
 		]);
 	}


### PR DESCRIPTION
- The recipe dropdown for consume should be limited to normal recipes. Where else should this be considered?
- The transfer page does not need to load recipes.