### PR TITLE
Fix is_aggregate_amount always 0 on stock_current

### DIFF
--- a/migrations/0106.sql
+++ b/migrations/0106.sql
@@ -1,3 +1,33 @@
+CREATE INDEX ix_products_performance1 ON products (
+    parent_product_id
+);
+
+CREATE INDEX ix_products_performance2 ON products (
+    CASE WHEN parent_product_id IS NULL THEN id ELSE parent_product_id END,
+    active
+);
+
+CREATE INDEX ix_stock_performance1 ON stock (
+    product_id,
+    open,
+    best_before_date,
+    amount
+);
+
+DROP VIEW products_resolved;
+CREATE VIEW products_resolved
+AS
+SELECT
+    CASE
+        WHEN p.parent_product_id IS NULL THEN
+            p.id
+        ELSE
+            p.parent_product_id
+    END AS parent_product_id,
+    p.id as sub_product_id
+FROM products p
+WHERE p.active = 1;
+
 DROP VIEW stock_missing_products_including_opened;
 CREATE VIEW stock_missing_products_including_opened
 AS

--- a/migrations/0108.sql
+++ b/migrations/0108.sql
@@ -9,7 +9,7 @@ SELECT
 	MIN(s.best_before_date) AS best_before_date,
 	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id AND open = 1), 0) AS amount_opened,
 	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id IN (SELECT sub_product_id FROM products_resolved WHERE parent_product_id = pr.parent_product_id) AND open = 1), 0) * IFNULL(qucr.factor, 1) AS amount_opened_aggregated,
-	CASE WHEN p_sub.parent_product_id IS NOT NULL THEN 1 ELSE 0 END AS is_aggregated_amount
+    CASE WHEN COUNT(p_sub.parent_product_id) > 0  THEN 1 ELSE 0 END AS is_aggregated_amount
 FROM products_resolved pr
 JOIN stock s
 	ON pr.sub_product_id = s.product_id


### PR DESCRIPTION
> I have no explanation, but any of the indexes created in that migration made that the stock_current view failed (the column is_aggregated_amount did not work anymore, returned always 0).
I searched for over an hour, but haven't found out what specific thing the problem is, it seems to be the combination of those indexes - strange...

I've found the issue:

is_aggregated_amount is not an aggregated column (not min(), avg(), sum(), etc.),
so sqlite picks a value from one of the rows in the group - from which row is undefined.

The indexes change how the query is executed, which causes sqlite to pick another row.

