### PR TITLE
Add row group customization

### DIFF
--- a/controllers/UsersApiController.php
+++ b/controllers/UsersApiController.php
@@ -219,6 +219,19 @@ class UsersApiController extends BaseApiController
 		}
 	}
 
+	public function DeleteUserSetting(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		try
+		{
+			$value = $this->getUsersService()->DeleteUserSetting(GROCY_USER_ID, $args['settingKey']);
+			return $this->EmptyApiResponse($response);
+		}
+		catch (\Exception $ex)
+		{
+			return $this->GenericErrorResponse($response, $ex->getMessage());
+		}
+	}
+
 	public function __construct(\DI\Container $container)
 	{
 		parent::__construct($container);

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -1299,6 +1299,38 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"summary": "Deletes the given setting of the currently logged in user",
+				"tags": [
+					"Current user"
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "settingKey",
+						"required": true,
+						"description": "The key of the user setting",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "The operation was successful"
+					},
+					"400": {
+						"description": "The operation was not successful",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error400"
+								}
+							}
+						}
+					}
+				}
 			}
 		},
 		"/stock": {

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -2017,3 +2017,9 @@ msgstr ""
 
 msgid "Ingredient group"
 msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Are you sure, you want reset the table?"
+msgstr ""

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Price per stock unit"
 msgstr ""
 
-msgid "Hide/view columns"
+msgid "Table options"
 msgstr ""
 
 msgid "This product is currently on a shopping list"
@@ -2021,5 +2021,11 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-msgid "Are you sure, you want reset the table?"
+msgid "Are you sure to reset the table options?"
+msgstr ""
+
+msgid "Table layout configuration"
+msgstr ""
+
+msgid "Hide/view columns"
 msgstr ""

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -2008,3 +2008,12 @@ msgstr ""
 
 msgid "Show on stock overview page"
 msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Group by"
+msgstr ""
+
+msgid "Ingredient group"
+msgstr ""

--- a/public/js/grocy.js
+++ b/public/js/grocy.js
@@ -765,17 +765,16 @@ $.extend(true, $.fn.dataTable.defaults, {
 	},
 	'preDrawCallback': function(settings)
 	{
-		//currently it is not possible to save the state of rowGroup via saveState events
+		// Currently it is not possible to save the state of rowGroup via saveState events
 		var api = new $.fn.dataTable.Api(settings);
 		if (typeof api.rowGroup === "function")
 		{
 			var settingKey = 'datatables_rowGroup_' + settings.sTableId;
-
 			if (Grocy.UserSettings[settingKey] !== undefined)
 			{
 				var rowGroup = JSON.parse(Grocy.UserSettings[settingKey]);
 
-				//check if there way changed. the draw event is called often therefore we have to check if it's really necessary
+				// Check if there way changed. the draw event is called often therefore we have to check if it's really necessary
 				if (rowGroup.enable !== api.rowGroup().enabled()
 					|| ("dataSrc" in rowGroup && rowGroup.dataSrc !== api.rowGroup().dataSrc()))
 				{
@@ -786,7 +785,7 @@ $.extend(true, $.fn.dataTable.defaults, {
 					{
 						api.rowGroup().dataSrc(rowGroup.dataSrc);
 
-						//apply fixed order for group column
+						// Apply fixed order for group column
 						var fixedOrder = {
 							pre: [rowGroup.dataSrc, 'asc']
 						};
@@ -977,11 +976,10 @@ $(".change-table-columns-visibility-button").on("click", function(e)
 		}
 	});
 
-	var message = '<div class="text-center"><h4>' + __t('Hide/view columns') + '</h4><div class="text-left form-group">' + columnCheckBoxesHtml + '</div></div>';
-
+	var message = '<div class="text-center"><h5>' + __t('Table options') + '</h5><hr><h5>' + __t('Hide/view columns') + '</h5><div class="text-left form-group">' + columnCheckBoxesHtml + '</div></div>';
 	if (rowGroupDefined)
 	{
-		message += '<hr><div class="text-center mt-1"><h4>' + __t('Group by') + '</h4><div class="text-left form-group">' + rowGroupRadioBoxesHtml + '</div></div>';
+		message += '<div class="text-center mt-1"><h5>' + __t('Group by') + '</h5><div class="text-left form-group">' + rowGroupRadioBoxesHtml + '</div></div>';
 	}
 
 	bootbox.dialog({
@@ -993,12 +991,12 @@ $(".change-table-columns-visibility-button").on("click", function(e)
 		buttons: {
 			reset: {
 				label: __t('Reset'),
-				className: 'btn-danger responsive-button',
+				className: 'btn-outline-danger float-left responsive-button',
 				callback: function()
 				{
 					bootbox.confirm({
 						swapButtonOrder: true,
-						message: __t("Are you sure, you want reset the table?"),
+						message: __t("Are you sure to reset the table options?"),
 						buttons: {
 							confirm: {
 								label: 'Yes',
@@ -1016,10 +1014,10 @@ $(".change-table-columns-visibility-button").on("click", function(e)
 								var dataTable = $(dataTableSelector).DataTable();
 								var tableId = dataTable.settings()[0].sTableId;
 
-								//Delete rowgroup settings
+								// Delete rowgroup settings
 								Grocy.FrontendHelpers.DeleteUserSetting('datatables_rowGroup_' + tableId);
 
-								//Delete state settings
+								// Delete state settings
 								dataTable.state.clear();
 							}
 							bootbox.hideAll();

--- a/public/js/grocy.js
+++ b/public/js/grocy.js
@@ -734,7 +734,7 @@ $.extend(true, $.fn.dataTable.defaults, {
 			return JSON.parse(Grocy.UserSettings[settingKey]);
 		}
 	},
-	"preDrawCallback": function(settings)
+	'preDrawCallback': function(settings)
 	{
 		//currently it is not possible to save the state of rowGroup via saveState events
 		var api = new $.fn.dataTable.Api(settings);
@@ -770,7 +770,10 @@ $.extend(true, $.fn.dataTable.defaults, {
 	},
 	'columnDefs': [
 		{ type: 'chinese-string', targets: '_all' }
-	]
+	],
+	'rowGroup': {
+		enable: false
+	}
 });
 
 // serializeJSON defaults

--- a/public/js/grocy.js
+++ b/public/js/grocy.js
@@ -454,14 +454,17 @@ Grocy.FrontendHelpers.SaveUserSetting = function(settingsKey, value)
 	);
 }
 
-Grocy.FrontendHelpers.DeleteUserSetting = function(settingsKey)
+Grocy.FrontendHelpers.DeleteUserSetting = function(settingsKey, reloadPageOnSuccess = false)
 {
 	delete Grocy.UserSettings[settingsKey];
 
 	Grocy.Api.Delete('user/settings/' + settingsKey, {},
 		function(result)
 		{
-			// Nothing to do...
+			if (reloadPageOnSuccess)
+			{
+				location.reload();
+			}
 		},
 		function(xhr)
 		{
@@ -739,7 +742,8 @@ $.extend(true, $.fn.dataTable.defaults, {
 		var settingKey = 'datatables_state_' + settings.sTableId;
 		if ($.isEmptyObject(data))
 		{
-			Grocy.FrontendHelpers.DeleteUserSetting(settingKey);
+			//state.clear was called and unfortunately the table is not refresh, so we are reloading the page
+			Grocy.FrontendHelpers.DeleteUserSetting(settingKey, true);
 		} else
 		{
 			var stateData = JSON.stringify(data);
@@ -1017,9 +1021,6 @@ $(".change-table-columns-visibility-button").on("click", function(e)
 
 								//Delete state settings
 								dataTable.state.clear();
-
-								//Reload page as datatable is not reseting itself
-								location.reload();
 							}
 							bootbox.hideAll();
 						}

--- a/public/viewjs/productform.js
+++ b/public/viewjs/productform.js
@@ -293,6 +293,7 @@ var quConversionsTable = $('#qu-conversions-table-products').DataTable({
 		{ 'visible': false, 'targets': 4 }
 	].concat($.fn.dataTable.defaults.columnDefs),
 	'rowGroup': {
+		enable: true,
 		dataSrc: 4
 	}
 });

--- a/public/viewjs/recipeform.js
+++ b/public/viewjs/recipeform.js
@@ -82,6 +82,7 @@ var recipesPosTables = $('#recipes-pos-table').DataTable({
 		{ 'visible': false, 'targets': 4 }
 	].concat($.fn.dataTable.defaults.columnDefs),
 	'rowGroup': {
+		enable: true,
 		dataSrc: 4
 	}
 });

--- a/public/viewjs/shoppinglist.js
+++ b/public/viewjs/shoppinglist.js
@@ -9,6 +9,7 @@ var shoppingListTable = $('#shoppinglist-table').DataTable({
 		{ 'visible': false, 'targets': 3 }
 	].concat($.fn.dataTable.defaults.columnDefs),
 	'rowGroup': {
+		enable: true,
 		dataSrc: 3,
 		startRender: function(rows, group)
 		{

--- a/public/viewjs/tasks.js
+++ b/public/viewjs/tasks.js
@@ -6,6 +6,7 @@
 		{ 'visible': false, 'targets': 3 }
 	].concat($.fn.dataTable.defaults.columnDefs),
 	'rowGroup': {
+		enable: true,
 		dataSrc: 3
 	}
 });

--- a/routes.php
+++ b/routes.php
@@ -175,6 +175,7 @@ $app->group('/api', function (RouteCollectorProxy $group) {
 	$group->get('/user/settings', '\Grocy\Controllers\UsersApiController:GetUserSettings');
 	$group->get('/user/settings/{settingKey}', '\Grocy\Controllers\UsersApiController:GetUserSetting');
 	$group->put('/user/settings/{settingKey}', '\Grocy\Controllers\UsersApiController:SetUserSetting');
+	$group->delete('/user/settings/{settingKey}', '\Grocy\Controllers\UsersApiController:DeleteUserSetting');
 
 	// Stock
 	if (GROCY_FEATURE_FLAG_STOCK)

--- a/services/UsersService.php
+++ b/services/UsersService.php
@@ -114,6 +114,11 @@ class UsersService extends BaseService
 		}
 	}
 
+	public function DeleteUserSetting($userId, $settingKey)
+	{
+		$this->getDatabase()->user_settings()->where('user_id = :1 AND key = :2', $userId, $settingKey)->delete();
+	}
+
 	private function UserExists($userId)
 	{
 		$userRow = $this->getDatabase()->users()->where('id = :1', $userId)->fetch();

--- a/views/batteries.blade.php
+++ b/views/batteries.blade.php
@@ -72,7 +72,7 @@
 				<tr>
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#batteries-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/batteriesjournal.blade.php
+++ b/views/batteriesjournal.blade.php
@@ -68,7 +68,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#batteries-journal-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/batteriesoverview.blade.php
+++ b/views/batteriesoverview.blade.php
@@ -90,7 +90,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#batteries-overview-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/chores.blade.php
+++ b/views/chores.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#chores-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/choresjournal.blade.php
+++ b/views/choresjournal.blade.php
@@ -68,7 +68,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#chores-journal-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/choresoverview.blade.php
+++ b/views/choresoverview.blade.php
@@ -112,7 +112,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#chores-overview-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/equipment.blade.php
+++ b/views/equipment.blade.php
@@ -63,7 +63,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#equipment-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -65,6 +65,8 @@
 		rel="stylesheet">
 	<link href="{{ $U('/node_modules/datatables.net-colreorder-bs4/css/colReorder.bootstrap4.min.css?v=', true) }}{{ $version }}"
 		rel="stylesheet">
+	<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}"
+		rel="stylesheet">
 	<link href="{{ $U('/node_modules/datatables.net-select-bs4/css/select.bootstrap4.min.css?v=', true) }}{{ $version }}"
 		rel="stylesheet">
 	<link href="{{ $U('/node_modules/toastr/build/toastr.min.css?v=', true) }}{{ $version }}"
@@ -684,10 +686,12 @@
 	<script src="{{ $U('/node_modules/datatables.net-bs4/js/dataTables.bootstrap4.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-colreorder/js/dataTables.colReorder.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-colreorder-bs4/js/colReorder.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
-	<script src="{{ $U('/node_modules/datatables.net-select/js/dataTables.select.min.js?v=', true) }}{{ $version }}"></script>
-	<script src="{{ $U('/node_modules/datatables.net-select-bs4/js/select.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-plugins/filtering/type-based/accent-neutralise.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-plugins/sorting/chinese-string.js?v=', true) }}{{ $version }}"></script>
+	<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
+	<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
+	<script src="{{ $U('/node_modules/datatables.net-select/js/dataTables.select.min.js?v=', true) }}{{ $version }}"></script>
+	<script src="{{ $U('/node_modules/datatables.net-select-bs4/js/select.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/timeago/jquery.timeago.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules', true) }}/timeago/locales/jquery.timeago.{{ $__t('timeago_locale') }}.js?v={{ $version }}"></script>
 	<script src="{{ $U('/node_modules/toastr/build/toastr.min.js?v=', true) }}{{ $version }}"></script>

--- a/views/locations.blade.php
+++ b/views/locations.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#locations-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/manageapikeys.blade.php
+++ b/views/manageapikeys.blade.php
@@ -78,7 +78,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#apikeys-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -580,7 +580,7 @@
 							<th>{{ $__t('Quantity unit from') }}</th>
 							<th>{{ $__t('Quantity unit to') }}</th>
 							<th>{{ $__t('Factor') }}</th>
-							<th class="d-none">Hidden group</th>
+							<th>{{ $__('Group')}}</th>
 							<th></th>
 						</tr>
 					</thead>

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -10,14 +10,10 @@
 
 @push('pageScripts')
 <script src="{{ $U('/node_modules/TagManager/tagmanager.js?v=', true) }}{{ $version }}"></script>
-<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
-<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
 @endpush
 
 @push('pageStyles')
 <link href="{{ $U('/node_modules/TagManager/tagmanager.css?v=', true) }}{{ $version }}"
-	rel="stylesheet">
-<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}"
 	rel="stylesheet">
 @endpush
 

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -468,7 +468,7 @@
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#barcode-table"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>
@@ -569,14 +569,14 @@
 						<tr>
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#qu-conversions-table-products"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>
 							<th>{{ $__t('Quantity unit from') }}</th>
 							<th>{{ $__t('Quantity unit to') }}</th>
 							<th>{{ $__t('Factor') }}</th>
-							<th>{{ $__('Group')}}</th>
+							<th>{{ $__t('Group')}}</th>
 							<th></th>
 						</tr>
 					</thead>

--- a/views/productgroups.blade.php
+++ b/views/productgroups.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#productgroups-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/products.blade.php
+++ b/views/products.blade.php
@@ -102,7 +102,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#products-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/quantityunitform.blade.php
+++ b/views/quantityunitform.blade.php
@@ -128,7 +128,7 @@
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#qu-conversions-table"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>

--- a/views/quantityunits.blade.php
+++ b/views/quantityunits.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#quantityunits-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/recipeform.blade.php
+++ b/views/recipeform.blade.php
@@ -8,16 +8,6 @@
 
 @section('viewJsName', 'recipeform')
 
-@push('pageScripts')
-<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
-<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
-@endpush
-
-@push('pageStyles')
-<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}"
-	rel="stylesheet">
-@endpush
-
 @section('content')
 <div class="row">
 	<div class="col">

--- a/views/recipeform.blade.php
+++ b/views/recipeform.blade.php
@@ -156,7 +156,7 @@
 							<th>{{ $__t('Product') }}</th>
 							<th>{{ $__t('Amount') }}</th>
 							<th class="fit-content">{{ $__t('Note') }}</th>
-							<th class="d-none">Hidden ingredient group</th>
+							<th>{{ $__t('Ingredient group') }}</th>
 						</tr>
 					</thead>
 					<tbody class="d-none">

--- a/views/recipeform.blade.php
+++ b/views/recipeform.blade.php
@@ -139,7 +139,7 @@
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#recipes-pos-table"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>
@@ -242,7 +242,7 @@
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#recipes-includes-table"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>

--- a/views/recipes.blade.php
+++ b/views/recipes.blade.php
@@ -102,7 +102,7 @@
 							<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 									data-toggle="tooltip"
 									data-toggle="tooltip"
-									title="{{ $__t('Hide/view columns') }}"
+									title="{{ $__t('Table options') }}"
 									data-table-selector="#recipes-table"
 									href="#"><i class="fas fa-eye"></i></a>
 							</th>

--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -20,7 +20,6 @@
 	tr.dtrg-group {
 		cursor: pointer;
 	}
-
 </style>
 @endpush
 
@@ -184,7 +183,7 @@
 					</th>
 					<th>{{ $__t('Product') }} / <em>{{ $__t('Note') }}</em></th>
 					<th>{{ $__t('Amount') }}</th>
-					<th class="d-none">Hidden product group</th>
+					<th>{{ $__t('Product group') }}</th>
 					<th class="d-none">Hidden status</th>
 
 					@include('components.userfields_thead', array(
@@ -251,7 +250,7 @@
 						@endif
 						<span class="locale-number locale-number-quantity-amount">{{ $listItem->amount }}</span> @if(!empty($listItem->product_id)){{ $__n($listItem->amount, FindObjectInArrayByPropertyValue($quantityunits, 'id', $listItem->qu_id)->name, FindObjectInArrayByPropertyValue($quantityunits, 'id', $listItem->qu_id)->name_plural) }}@endif
 					</td>
-					<td class="d-none">
+					<td>
 						@if(!empty(FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->product_group_id)) {{ FindObjectInArrayByPropertyValue($productGroups, 'id', FindObjectInArrayByPropertyValue($products, 'id', $listItem->product_id)->product_group_id)->name }} @else <span class="font-italic font-weight-light">{{ $__t('Ungrouped') }}</span> @endif
 					</td>
 					<td id="shoppinglistitem-{{ $listItem->id }}-status-info"

--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -5,15 +5,11 @@
 @section('viewJsName', 'shoppinglist')
 
 @push('pageScripts')
-<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
-<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
 <script src="{{ $U('/viewjs/purchase.js?v=', true) }}{{ $version }}"></script>
 @endpush
 
 @push('pageStyles')
 <link href="{{ $U('/node_modules/animate.css/animate.min.css?v=', true) }}{{ $version }}"
-	rel="stylesheet">
-<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}"
 	rel="stylesheet">
 
 <style>

--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -16,6 +16,7 @@
 	tr.dtrg-group {
 		cursor: pointer;
 	}
+
 </style>
 @endpush
 
@@ -173,7 +174,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#shoppinglist-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/shoppinglocations.blade.php
+++ b/views/shoppinglocations.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#shoppinglocations-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/stockentries.blade.php
+++ b/views/stockentries.blade.php
@@ -58,7 +58,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#stockentries-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/stockjournal.blade.php
+++ b/views/stockjournal.blade.php
@@ -121,7 +121,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#stock-journal-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/stockjournalsummary.blade.php
+++ b/views/stockjournalsummary.blade.php
@@ -96,7 +96,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#stock-journal-summary-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -152,7 +152,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#stock-overview-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/taskcategories.blade.php
+++ b/views/taskcategories.blade.php
@@ -73,7 +73,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#taskcategories-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -114,7 +114,7 @@
 					</th>
 					<th>{{ $__t('Task') }}</th>
 					<th>{{ $__t('Due') }}</th>
-					<th class="d-none">Hidden category</th>
+					<th>{{ $__t('Category') }}</th>
 					<th>{{ $__t('Assigned to') }}</th>
 					<th class="d-none">Hidden status</th>
 
@@ -176,7 +176,7 @@
 						<time class="timeago timeago-contextual"
 							datetime="{{ $task->due_date }}"></time>
 					</td>
-					<td class="d-none">
+					<td>
 						@if($task->category_id != null) <span>{{ FindObjectInArrayByPropertyValue($taskCategories, 'id', $task->category_id)->name }}</span> @else <span class="font-italic font-weight-light">{{ $__t('Uncategorized') }}</span>@endif
 					</td>
 					<td>

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -4,15 +4,8 @@
 @section('activeNav', 'tasks')
 @section('viewJsName', 'tasks')
 
-@push('pageScripts')
-<script src="{{ $U('/node_modules/datatables.net-rowgroup/js/dataTables.rowGroup.min.js?v=', true) }}{{ $version }}"></script>
-<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
-@endpush
-
 @push('pageStyles')
 <link href="{{ $U('/node_modules/animate.css/animate.min.css?v=', true) }}{{ $version }}"
-	rel="stylesheet">
-<link href="{{ $U('/node_modules/datatables.net-rowgroup-bs4/css/rowGroup.bootstrap4.min.css?v=', true) }}{{ $version }}"
 	rel="stylesheet">
 @endpush
 

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -101,7 +101,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#tasks-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/userentities.blade.php
+++ b/views/userentities.blade.php
@@ -69,7 +69,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#userentities-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/userfields.blade.php
+++ b/views/userfields.blade.php
@@ -84,7 +84,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#userfields-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>

--- a/views/users.blade.php
+++ b/views/users.blade.php
@@ -69,7 +69,7 @@
 					<th class="border-right"><a class="text-muted change-table-columns-visibility-button"
 							data-toggle="tooltip"
 							data-toggle="tooltip"
-							title="{{ $__t('Hide/view columns') }}"
+							title="{{ $__t('Table options') }}"
 							data-table-selector="#users-table"
 							href="#"><i class="fas fa-eye"></i></a>
 					</th>


### PR DESCRIPTION
Add the possibility to change the row group of a table similar to hide/view columns. The row group configuration will be stored with the other state settings of the table in the user settings.

Screenshot of the shoppinglist customizations:
![grafik](https://user-images.githubusercontent.com/26537646/102270113-e7c54a00-3f1d-11eb-84c4-d02974c25e19.png)

Selecting "none" will disable the rowGroup feature and disable the fixed order.
Selecting a column will group it after the column and also activate a fixed order for that column. (In the code I have found, that when rowGroup is activated also fixedOrder on that column was applied)


Currently the Group by section is shown only if rowGroup extension is added to table, which is currently the case for shoppinglist, tasks, productform, recipeform.
@berrnd Should we enable the possibility for all tables?
