### PR TITLE
Fix: Show print button also when using only one shoppinglist

### DIFF
--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -77,6 +77,14 @@
 				name="selected-shopping-list"
 				id="selected-shopping-list"
 				value="1">
+			<div class="related-links collapse d-md-flex order-2 width-xs-sm-100"
+				id="related-links">
+				<a id="print-shopping-list-button"
+					class="btn btn-outline-dark responsive-button m-1 mt-md-0 mb-md-0 float-right"
+					href="#">
+					{{ $__t('Print') }}
+				</a>
+			</div>
 			@endif
 		</div>
 		<div class="border-top border-bottom my-2 py-1">


### PR DESCRIPTION
Show the print button also when `GROCY_FEATURE_FLAG_SHOPPINGLIST_MULTIPLE_LISTS` is set to false