### PR TITLE
Fix openapi for userentities

### DIFF
--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -571,7 +571,14 @@
 						"required": true,
 						"description": "A valid entity name",
 						"schema": {
-							"$ref": "#/components/internalSchemas/ExposedEntity"
+							"oneOf": [
+								{
+									"$ref": "#/components/internalSchemas/ExposedEntity"
+								},
+								{
+									"$ref": "#/components/internalSchemas/ExposedUserEntity"
+								}
+							]
 						}
 					},
 					{
@@ -620,7 +627,14 @@
 						"required": true,
 						"description": "A valid entity name",
 						"schema": {
-							"$ref": "#/components/internalSchemas/ExposedEntity_NotIncludingNotEditable"
+							"oneOf": [
+								{
+									"$ref": "#/components/internalSchemas/ExposedEntity_NotIncludingNotEditable"
+								},
+								{
+									"$ref": "#/components/internalSchemas/ExposedUserEntity"
+								}
+							]
 						}
 					},
 					{
@@ -3941,6 +3955,10 @@
 					"stock_current_locations",
 					"api_keys"
 				]
+			},
+			"ExposedUserEntity": {
+				"type": "string",
+				"pattern": "^userentity-"
 			},
 			"ExposedEntityNoListing": {
 				"type": "string",


### PR DESCRIPTION
Currently the openapi allows only the predefined enum value (`#/components/internalSchemas/ExposedEntity`) as parameter `entity` on the api call `/userfields/{entity}/{objectId}`.
When using user entities, they will use `userentity-{name}` as entity, which would be a violation of the openapi schema.

Extended the parameter `entity` of `/userfields/{entity}/{objectId}` to allow also string with the following pattern ` ^userentity-`.
Is the openapi generated or is this manual change fine?