### PR TITLE
Added /system/time API call

### DIFF
--- a/controllers/SystemApiController.php
+++ b/controllers/SystemApiController.php
@@ -46,8 +46,9 @@ class SystemApiController extends BaseApiController
 	public function GetSystemTime(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
 		$offset = 0;
-		if (isset($args['offset']))
-			$offset = $args['offset'];
+		$params = $request->getQueryParams();
+		if (isset($params['offset']))
+			$offset = $params['offset'];
 		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime($offset));
 	}
 

--- a/controllers/SystemApiController.php
+++ b/controllers/SystemApiController.php
@@ -45,11 +45,26 @@ class SystemApiController extends BaseApiController
 
 	public function GetSystemTime(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
-		$offset = 0;
-		$params = $request->getQueryParams();
-		if (isset($params['offset']))
-			$offset = $params['offset'];
-		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime($offset));
+		try
+		{
+			$offset = 0;
+			$params = $request->getQueryParams();
+			if (isset($params['offset']))
+			{
+				if (!filter_var($params['offset'], FILTER_VALIDATE_INT))
+				{
+					throw new \Exception('Query parameter "offset" is not a valid integer');
+				}
+
+				$offset = $params['offset'];
+			}
+
+			return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime($offset));
+		}
+		catch (\Exception $ex)
+		{
+			return $this->GenericErrorResponse($response, $ex->getMessage());
+		}
 	}
 
 	public function LogMissingLocalization(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)

--- a/controllers/SystemApiController.php
+++ b/controllers/SystemApiController.php
@@ -43,6 +43,11 @@ class SystemApiController extends BaseApiController
 		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemInfo());
 	}
 
+	public function GetSystemTime(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
+	{
+		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime());
+	}
+
 	public function LogMissingLocalization(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
 		if (GROCY_MODE === 'dev')

--- a/controllers/SystemApiController.php
+++ b/controllers/SystemApiController.php
@@ -45,7 +45,10 @@ class SystemApiController extends BaseApiController
 
 	public function GetSystemTime(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)
 	{
-		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime());
+		$offset = 0;
+		if (isset($args['offset']))
+			$offset = $args['offset'];
+		return $this->ApiResponse($response, $this->getApplicationService()->GetSystemTime($offset));
 	}
 
 	public function LogMissingLocalization(\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response, array $args)

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -146,6 +146,41 @@
 				}
 			}
 		},
+		"/system/time": {
+			"get": {
+				"summary": "Returns the current server time",
+				"tags": [
+					"System"
+				],
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/offsettime"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "A TimeResponse object",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TimeResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "The operation was not successful",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error400"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/system/log-missing-localization": {
 			"post": {
 				"summary": "Logs a missing localization string",
@@ -5170,6 +5205,28 @@
 					}
 				}
 			},
+			"TimeResponse": {
+				"type": "object",
+				"properties": {
+					"timezone": {
+						"type": "string"
+					},
+					"time_local": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"time_utc": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"timestamp": {
+						"type": "integer"
+					},
+					"offset": {
+						"type": "integer"
+					}
+				}
+			},
 			"UserSetting": {
 				"type": "object",
 				"properties": {
@@ -5218,6 +5275,15 @@
 				"name": "offset",
 				"required": false,
 				"description": "The number of objects to skip",
+				"schema": {
+					"type": "integer"
+				}
+			},
+			"offsettime": {
+				"in": "query",
+				"name": "offset",
+				"required": false,
+				"description": "Offset of timestamp in seconds. Can be positive or negative.",
 				"schema": {
 					"type": "integer"
 				}

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5215,6 +5215,10 @@
 						"type": "string",
 						"format": "date-time"
 					},
+					"time_local_sqlite3": {
+						"type": "string",
+						"format": "date-time"
+					},
 					"time_utc": {
 						"type": "string",
 						"format": "date-time"

--- a/routes.php
+++ b/routes.php
@@ -145,6 +145,7 @@ $app->group('/api', function (RouteCollectorProxy $group) {
 
 	// System
 	$group->get('/system/info', '\Grocy\Controllers\SystemApiController:GetSystemInfo');
+	$group->get('/system/time', '\Grocy\Controllers\SystemApiController:GetSystemTime');
 	$group->get('/system/db-changed-time', '\Grocy\Controllers\SystemApiController:GetDbChangedTime');
 	$group->get('/system/config', '\Grocy\Controllers\SystemApiController:GetConfig');
 	$group->post('/system/log-missing-localization', '\Grocy\Controllers\SystemApiController:LogMissingLocalization');

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -75,4 +75,31 @@ class ApplicationService extends BaseService
 			'sqlite_version' => $sqliteVersion
 		];
 	}
+
+	private static function convertToUtc(int $timestamp):string
+	{
+		$timestamp = time();
+		$dt = new DateTime('now', new DateTimeZone('UTC'));
+		$dt->setTimestamp($timestamp);
+		return $dt->format('Y-m-d H:i:s');
+	}
+
+	/**
+	 * Returns the response for the API call /system/time
+	 * @param int $offset an offset to be applied
+	 * @return array
+	 */
+	public function GetSystemTime(int $offset = 0):array
+	{
+		$timestamp = time();
+		$timeLocal = date('Y-m-d H:i:s', $timestamp);
+		$timeUTC = self::convertToUtc($timestamp);
+		return [
+			'timezone' => date_default_timezone_get(),
+			'time_local' => $timeLocal,
+			'time_utc' => $timeUTC,
+			'timestamp' => $timestamp,
+			'offset' => $offset
+		];
+	}
 }

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -87,7 +87,10 @@ class ApplicationService extends BaseService
 	private static function getSqliteLocaltime(int $offset):string
 	{
 		$pdo = new \PDO('sqlite::memory:');
-		return $pdo->query('SELECT datetime(\'now\', \'+' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
+		if ($offset > 0)
+			return $pdo->query('SELECT datetime(\'now\', \'+' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
+		else
+			return $pdo->query('SELECT datetime(\'now\', \'' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
 	}
 
 	/**

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -85,7 +85,7 @@ class ApplicationService extends BaseService
 
 	/**
 	 * Returns the response for the API call /system/time
-	 * @param int $offset an offset to be applied
+	 * @param int $offset an offset in seconds to be applied
 	 * @return array
 	 */
 	public function GetSystemTime(int $offset = 0):array

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -78,7 +78,6 @@ class ApplicationService extends BaseService
 
 	private static function convertToUtc(int $timestamp):string
 	{
-		$timestamp = time();
 		$dt = new \DateTime('now', new \DateTimeZone('UTC'));
 		$dt->setTimestamp($timestamp);
 		return $dt->format('Y-m-d H:i:s');

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -83,6 +83,13 @@ class ApplicationService extends BaseService
 		return $dt->format('Y-m-d H:i:s');
 	}
 
+
+	private static function getSqliteLocaltime(int $offset):string
+	{
+		$pdo = new \PDO('sqlite::memory:');
+		return $pdo->query('SELECT datetime(\'now\', \'+' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
+	}
+
 	/**
 	 * Returns the response for the API call /system/time
 	 * @param int $offset an offset in seconds to be applied
@@ -90,15 +97,16 @@ class ApplicationService extends BaseService
 	 */
 	public function GetSystemTime(int $offset = 0):array
 	{
-		$timestamp = time()+$offset;
+		$timestamp = time() + $offset;
 		$timeLocal = date('Y-m-d H:i:s', $timestamp);
 		$timeUTC = self::convertToUtc($timestamp);
 		return [
-			'timezone' => date_default_timezone_get(),
-			'time_local' => $timeLocal,
-			'time_utc' => $timeUTC,
-			'timestamp' => $timestamp,
-			'offset' => $offset
+			'timezone'           => date_default_timezone_get(),
+			'time_local'         => $timeLocal,
+			'time_local_sqlite3' => self::getSqliteLocaltime($offset),
+			'time_utc'           => $timeUTC,
+			'timestamp'          => $timestamp,
+			'offset'             => $offset
 		];
 	}
 }

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -76,21 +76,24 @@ class ApplicationService extends BaseService
 		];
 	}
 
-	private static function convertToUtc(int $timestamp):string
+	private static function convertToUtc(int $timestamp): string
 	{
 		$dt = new \DateTime('now', new \DateTimeZone('UTC'));
 		$dt->setTimestamp($timestamp);
 		return $dt->format('Y-m-d H:i:s');
 	}
 
-
-	private static function getSqliteLocaltime(int $offset):string
+	private static function getSqliteLocaltime(int $offset): string
 	{
 		$pdo = new \PDO('sqlite::memory:');
 		if ($offset > 0)
+		{
 			return $pdo->query('SELECT datetime(\'now\', \'+' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
+		}
 		else
+		{
 			return $pdo->query('SELECT datetime(\'now\', \'' . $offset . ' seconds\', \'localtime\');')->fetch()[0];
+		}
 	}
 
 	/**
@@ -98,18 +101,18 @@ class ApplicationService extends BaseService
 	 * @param int $offset an offset in seconds to be applied
 	 * @return array
 	 */
-	public function GetSystemTime(int $offset = 0):array
+	public function GetSystemTime(int $offset = 0): array
 	{
 		$timestamp = time() + $offset;
 		$timeLocal = date('Y-m-d H:i:s', $timestamp);
 		$timeUTC = self::convertToUtc($timestamp);
 		return [
-			'timezone'           => date_default_timezone_get(),
-			'time_local'         => $timeLocal,
+			'timezone' => date_default_timezone_get(),
+			'time_local' => $timeLocal,
 			'time_local_sqlite3' => self::getSqliteLocaltime($offset),
-			'time_utc'           => $timeUTC,
-			'timestamp'          => $timestamp,
-			'offset'             => $offset
+			'time_utc' => $timeUTC,
+			'timestamp' => $timestamp,
+			'offset' => $offset
 		];
 	}
 }

--- a/services/ApplicationService.php
+++ b/services/ApplicationService.php
@@ -79,7 +79,7 @@ class ApplicationService extends BaseService
 	private static function convertToUtc(int $timestamp):string
 	{
 		$timestamp = time();
-		$dt = new DateTime('now', new DateTimeZone('UTC'));
+		$dt = new \DateTime('now', new \DateTimeZone('UTC'));
 		$dt->setTimestamp($timestamp);
 		return $dt->format('Y-m-d H:i:s');
 	}
@@ -91,7 +91,7 @@ class ApplicationService extends BaseService
 	 */
 	public function GetSystemTime(int $offset = 0):array
 	{
-		$timestamp = time();
+		$timestamp = time()+$offset;
 		$timeLocal = date('Y-m-d H:i:s', $timestamp);
 		$timeUTC = self::convertToUtc($timestamp);
 		return [


### PR DESCRIPTION
As Grocy is using local time for all database entries, I needed a call to get the server's timezone.

This also outputs local time and UTC and an offset can be applied, which can be useful for external programs.