### PR TITLE
Show "manage user" menu entry also when the auth view is diabled

### DIFF
--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -628,13 +628,11 @@
 							<i class="fas fa-user-cog"></i> {{ $__t('User settings') }}
 						</a>
 						<div class="dropdown-divider"></div>
-						@if(GROCY_SHOW_AUTH_VIEWS)
 						<a class="dropdown-item discrete-link permission-USERS_READ"
 							href="{{ $U('/users') }}"><i class="fas fa-users"></i>&nbsp;{{ $__t('Manage users') }}</a>
 						<div class="dropdown-divider"></div>
 						<a class="dropdown-item discrete-link"
 							href="{{ $U('/manageapikeys') }}"><i class="fas fa-handshake"></i>&nbsp;{{ $__t('Manage API keys') }}</a>
-						@endif
 						<a class="dropdown-item discrete-link"
 							target="_blank"
 							href="{{ $U('/api') }}"><i class="fas fa-book"></i>&nbsp;{{ $__t('REST API & data model documentation') }}</a>


### PR DESCRIPTION
I don't know, why in first place the menu entries for managing users and api keys are disabled, when the auth view is disabled.
I started to use the `ReverseProxyAuthMiddleware` and handle the login with authelia. With #1216 it's now possible to use api keys with `ReverseProxyAuthMiddleware` and therefore we need again the menu entries.

Workaround until a new version is build, it is possible to to access the missing funtionality by inserting the direct url `/users` or `/manageapikeys`