### PR TITLE
Fixed shoppinglist JS, fix for #1289 and #1261

### DIFF
--- a/public/viewjs/shoppinglistitemform.js
+++ b/public/viewjs/shoppinglistitemform.js
@@ -244,16 +244,13 @@ if (GetUriParam("embedded") !== undefined)
 }
 
 var eitherRequiredFields = $("#product_id,#product_id_text_input,#note");
-eitherRequiredFields.on("input", function()
+eitherRequiredFields.prop('required',"");
+eitherRequiredFields.on('input', function ()
 {
-	eitherRequiredFields.attr("required", "");
-	if (!$(this).val().isEmpty())
-	{
-		eitherRequiredFields.not(this).removeAttr("required");
-	}
-
+	eitherRequiredFields.not(this).prop('required', !$(this).val().length);
 	Grocy.FrontendHelpers.ValidateForm('shoppinglist-form');
 });
+
 
 if (GetUriParam("product-name") != null)
 {


### PR DESCRIPTION
Now the fields are properly checked and the error does not show up anymore.
The only minor issue is that the save button is disabled if editing a shoppinglist note without a product, but as soon as the note is changed, the save button is enabled again. However as no errormessages are shown and it kind of makes sense that you cannot save the item without any changes first I did not add another validation in this PR.