### PR TITLE
Improved support for other LDAP servers

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -78,9 +78,12 @@ Setting('AUTH_CLASS', 'Grocy\Middleware\DefaultAuthMiddleware');
 Setting('REVERSE_PROXY_AUTH_HEADER', 'REMOTE_USER');
 
 // When using LdapAuthMiddleware
-Setting('LDAP_DOMAIN', ''); // Example value "local"
 Setting('LDAP_ADDRESS', ''); // Example value "ldap://vm-dc2019.local.berrnd.net"
-Setting('LDAP_BASE_DN', ''); // Example value "OU=OU_Users,DC=local,DC=berrnd,DC=net"
+Setting('LDAP_BASE_DN', ''); // Example value "DC=local,DC=berrnd,DC=net"
+Setting('LDAP_BIND_DN', ''); // Example value "CN=grocy_bind_account,OU=service_accounts,DC=local,DC=berrnd,DC=net"
+Setting('LDAP_BIND_PW', ''); // Password for the above account
+Setting('LDAP_USER_FILTER', ''); // Example value "(OU=grocy_users)"
+Setting('LDAP_UID_ATTR', ''); // Windows AD: "sAMAccountName", OpenLDAP: "uid", Glauth: "cn"
 
 // Set this to true if you want to disable the ability to scan a barcode via the device camera (Browser API)
 Setting('DISABLE_BROWSER_BARCODE_CAMERA_SCANNING', false);


### PR DESCRIPTION
### Changes
- Changed LDAP authentication to double bind (1st bind with read-only service account, 2nd bind to authenticate user)
- LDAP username attribute defined in config.php
- Added optional LDAP filter in config.php

### Tests
Tested with Windows 2019 AD (LDAP+LDAPS), OpenLDAP (LDAP) and GLauth (LDAP+LDAPS)
```
// Windows AD LDAP
Setting('LDAP_ADDRESS', 'ldap://winad.windows.ad:389');
Setting('LDAP_BASE_DN', 'DC=windows,DC=ad');
Setting('LDAP_BIND_DN', 'CN=Grocy Bind Account,OU=Service Accounts,DC=windows,DC=ad');
Setting('LDAP_BIND_PW', 'Password1!');
Setting('LDAP_USER_FILTER', '(memberof=CN=Grocy Users,OU=Users,DC=windows,DC=ad)');
Setting('LDAP_UID_ATTR', 'sAMAccountName');

// Windows AD LDAPS
Setting('LDAP_ADDRESS', 'ldaps://winad.windows.ad:636');
Setting('LDAP_BASE_DN', 'DC=windows,DC=ad');
Setting('LDAP_BIND_DN', 'CN=Grocy Bind Account,OU=Service Accounts,DC=windows,DC=ad');
Setting('LDAP_BIND_PW', 'Password1!');
Setting('LDAP_USER_FILTER', '(memberof=CN=Grocy Users,OU=Users,DC=windows,DC=ad)');
Setting('LDAP_UID_ATTR', 'sAMAccountName');

// GLauth LDAP(S)
Setting('LDAP_ADDRESS', 'ldaps://glauth.com:636');
Setting('LDAP_BASE_DN', 'dc=glauth,dc=com');
Setting('LDAP_BIND_DN', 'cn=grocy_bind_account,ou=service_accounts,dc=glauth,dc=com');
Setting('LDAP_BIND_PW', 'password');
Setting('LDAP_USER_FILTER', '(ou=grocy_users)');
Setting('LDAP_UID_ATTR', 'cn');

// OpenLDAP
Setting('LDAP_ADDRESS', 'ldap://openldap.ad:389');
Setting('LDAP_BASE_DN', 'dc=openldap,dc=ad');
Setting('LDAP_BIND_DN', 'cn=grocy bind,ou=People,dc=openldap,dc=ad');
Setting('LDAP_BIND_PW', 'password');
Setting('LDAP_USER_FILTER', '');
Setting('LDAP_UID_ATTR', 'uid');
```