### PR TITLE
Added support for Code 39

### DIFF
--- a/public/viewjs/components/barcodescanner.js
+++ b/public/viewjs/components/barcodescanner.js
@@ -101,7 +101,8 @@ Grocy.Components.BarcodeScanner.StartScanning = function()
 				"ean_reader",
 				"ean_8_reader",
 				"code_128_reader",
-				"datamatrix"
+				"datamatrix",
+				"code_39_reader"
 			],
 			debug: {
 				showCanvas: Grocy.UserSettings.quagga2_debug,
@@ -174,7 +175,8 @@ Quagga.onDetected(function(result)
 		}
 	});
 
-	if (Grocy.Components.BarcodeScanner.DecodedCodesErrorCount / Grocy.Components.BarcodeScanner.DecodedCodesCount < 0.15)
+	if ((Grocy.Components.BarcodeScanner.DecodedCodesErrorCount / Grocy.Components.BarcodeScanner.DecodedCodesCount < 0.15) ||
+		(Grocy.Components.BarcodeScanner.DecodedCodesErrorCount == 0 && Grocy.Components.BarcodeScanner.DecodedCodesCount == 0 && result.codeResult.code.length != 0))
 	{
 		Grocy.Components.BarcodeScanner.StopScanning();
 		$(document).trigger("Grocy.BarcodeScanned", [result.codeResult.code, Grocy.Components.BarcodeScanner.CurrentTarget]);


### PR DESCRIPTION
Hi all,

I was looking for support in managing our medicine cabinet and to track which drugs are available.

In Germany, packages of drugs have also a printed barcode that encodes their PZN number which is some kind of EAN for pharmaceutics. However, this barcode is encoded as Code 39 barcode which is currently not supported by the build-in barcode reader. In this pull request, I have added the support for code 39. 

During my tests, I figured out that (at least for code 39), an error rate is not added for each digit all the time. Thus, the onDetect function did not work (ErrorCount & DecodedCodesCount are both 0, i.e. NaN). Thus, I have extended the if-clause to cover also the case that both counts are 0, but there is a scanned code.

Hopefully, this request is fine so far and gets integrated :-)

In case there are more questions, happy to discuss.

BR
André