### PR TITLE
Extend REQUIRED_PHP_EXTENSIONS check about core extensions

### DIFF
--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -4,7 +4,7 @@ class ERequirementNotMet extends Exception
 {
 }
 
-const REQUIRED_PHP_EXTENSIONS = ['fileinfo', 'pdo_sqlite', 'gd', 'ctype', 'json', 'intl', 'zlib'];
+const REQUIRED_PHP_EXTENSIONS = ['fileinfo', 'pdo_sqlite', 'gd', 'ctype', 'json', 'intl', 'zlib', 'filter', 'iconv', 'tokenizer'];
 const REQUIRED_SQLITE_VERSION = '3.9.0';
 
 class PrerequisiteChecker

--- a/helpers/PrerequisiteChecker.php
+++ b/helpers/PrerequisiteChecker.php
@@ -4,7 +4,11 @@ class ERequirementNotMet extends Exception
 {
 }
 
-const REQUIRED_PHP_EXTENSIONS = ['fileinfo', 'pdo_sqlite', 'gd', 'ctype', 'json', 'intl', 'zlib', 'filter', 'iconv', 'tokenizer'];
+const REQUIRED_PHP_EXTENSIONS = ['fileinfo', 'pdo_sqlite', 'gd', 'ctype', 'json', 'intl', 'zlib',
+	// These are core extensions, so normally can't be missing, but seems to be the case, however, on FreeBSD
+	'filter', 'iconv', 'tokenizer'
+];
+
 const REQUIRED_SQLITE_VERSION = '3.9.0';
 
 class PrerequisiteChecker


### PR DESCRIPTION
After installing Grocy on FreeBSD, even with all extensions installed that are listed in REQUIRED_PHP_EXTENSIONS, Grocy still couldn't start. The added 3 PHP Extensions are also needed to run Grocy.