### PR TITLE
Fixed the bug where grocy would return "Not a grocycode" all the time

### DIFF
--- a/helpers/Grocycode.php
+++ b/helpers/Grocycode.php
@@ -77,7 +77,7 @@ class Grocycode
 			$gc = new self($code);
 			return true;
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}
@@ -110,7 +110,7 @@ class Grocycode
 	 */
 	private function setFromCode($code)
 	{
-		$parts = array_reverse(explode(':', $barcode));
+		$parts = array_reverse(explode(':', $code));
 		if (array_pop($parts) != self::MAGIC)
 		{
 			throw new \Exception('Not a grocycode');
@@ -122,7 +122,7 @@ class Grocycode
 		}
 
 		$this->id = array_pop($parts);
-		$this->extra_data = array_reverse($parse);
+		$this->extra_data = array_reverse($parts);
 	}
 
 	/**


### PR DESCRIPTION
When making a request to `/api/stock/products/by-barcode/{barcode}` using a "normal" barcode, Grocy would return a "Not a grocycode" Exception. 

This is really annoying when using the API to search for products using their barcode. 

Turned out the Try-Catch wasn't build correctly and the Exception wasn't catched but just returned as an Exception. Also changed some small variable mistakes in the function I worked on.