### PR TITLE
Fix exception handling

### DIFF
--- a/helpers/Grocycode.php
+++ b/helpers/Grocycode.php
@@ -77,7 +77,7 @@ class Grocycode
 			$gc = new self($code);
 			return true;
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}


### PR DESCRIPTION
I have tried to use the API endpoint ```/stock/products/by-barcode/{barcode}/add```. But I always got the error ```{"error_message":"Not a grocycode"}```. Even if I use a normal barcode (not a grocycode).

The try catch was not caught correctly because an import is faulty. 