### PR TITLE
Change PHP Dependency from >= to ^

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
+	"name": "grocy/grocy",
+	"description": "ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home",
+	"license": "MIT",
 	"require": {
-		"php": ">=8.0",
+		"php": "^8.0",
 		"slim/slim": "^4.0",
 		"slim/psr7": "^1.0",
 		"slim/http": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,4 @@
 {
-	"name": "grocy/grocy",
-	"description": "ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home",
-	"license": "MIT",
 	"require": {
 		"php": "^8.0",
 		"slim/slim": "^4.0",


### PR DESCRIPTION
In composer.json it is better not to work with `>=` in PHP. When the next PHP version is released (with breaking changes) there will be problems. `^` is more suitable, because you only allow minor patches here.

I also added a name and a description so the json is valid.