### PR TITLE
Add missing urldecode

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -161,7 +161,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->AddProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)
@@ -322,7 +322,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->ConsumeProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)
@@ -496,7 +496,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->InventoryProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)
@@ -550,7 +550,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->OpenProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)
@@ -575,7 +575,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$productId = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$productId = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->ApiResponse($response, $this->getStockService()->GetProductDetails($productId));
 		}
 		catch (\Exception $ex)
@@ -804,7 +804,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode(urldecode($args['barcode']));
 			return $this->TransferProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)


### PR DESCRIPTION
I wanted to use an API endpoint that requires {barcode}. My barcodes contain special characters. For example, spaces.

Example barcode: `CHEESE 123` (with space)

In the URL this is passed as `CHEESE+123` or `CHEESE%20123` due to encoding which cannot be found in the database.

The code has not yet decoded the input from the URI. This is not normally necessary with "normal" barcodes. I have added this in any case. 

This should actually have no further effect on other barcodes. 
I have tested GrocyCode -> works
