### PR TITLE
fix: make stockentry grocycodes consume the actual stock entry not the product in general

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -282,6 +282,10 @@ class StockApiController extends BaseApiController
 			{
 				$specificStockEntryId = $requestBody['stock_entry_id'];
 			}
+            else if (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
+            {
+				$specificStockEntryId = $args['stock_id'];
+            }
 
 			$locationId = null;
 			if (array_key_exists('location_id', $requestBody) && !empty($requestBody['location_id']) && is_numeric($requestBody['location_id']))
@@ -322,7 +326,23 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+	    if (Grocycode::Validate($barcode))
+	    {
+	        $gc = new Grocycode($barcode);
+	        if ($gc->GetType() != Grocycode::PRODUCT)
+	        {
+	            throw new \Exception("Invalid grocycode type");
+	        }
+	        $args['productId'] = $gc->GetId();
+	        if ($gc->GetExtraData())
+	        {
+	            $args['stock_id'] = $gc->GetExtraData()[0];
+	        }
+	    }
+	    else
+	    {
+	        $args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+	    }
 			return $this->ConsumeProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -278,11 +278,7 @@ class StockApiController extends BaseApiController
 			}
 
 			$specificStockEntryId = 'default';
-			if (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
-			{
-				$specificStockEntryId = $args['stock_id'];
-			}
-			elseif (array_key_exists('stock_entry_id', $requestBody) && !empty($requestBody['stock_entry_id']))
+			if (array_key_exists('stock_entry_id', $requestBody) && !empty($requestBody['stock_entry_id']))
 			{
 				$specificStockEntryId = $requestBody['stock_entry_id'];
 			}
@@ -326,24 +322,19 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-			$barcode = $args['barcode'];
-			if (Grocycode::Validate($barcode))
+			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+
+			if (Grocycode::Validate($args['barcode']))
 			{
-				$gc = new Grocycode($barcode);
-				if ($gc->GetType() != Grocycode::PRODUCT)
-				{
-					throw new \Exception('Invalid grocycode type');
-				}
-				$args['productId'] = $gc->GetId();
+				$gc = new Grocycode($args['barcode']);
 				if ($gc->GetExtraData())
 				{
-					$args['stock_id'] = $gc->GetExtraData()[0];
+					$requestBody = $request->getParsedBody();
+					$requestBody['stock_entry_id'] = $gc->GetExtraData()[0];
+					$request = $request->withParsedBody($requestBody);
 				}
 			}
-			else
-			{
-				$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
-			}
+
 			return $this->ConsumeProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -278,13 +278,13 @@ class StockApiController extends BaseApiController
 			}
 
 			$specificStockEntryId = 'default';
-			if (array_key_exists('stock_entry_id', $requestBody) && !empty($requestBody['stock_entry_id']))
-			{
-				$specificStockEntryId = $requestBody['stock_entry_id'];
-			}
-			elseif (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
+			if (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
 			{
 				$specificStockEntryId = $args['stock_id'];
+			}
+			elseif (array_key_exists('stock_entry_id', $requestBody) && !empty($requestBody['stock_entry_id']))
+			{
+				$specificStockEntryId = $requestBody['stock_entry_id'];
 			}
 
 			$locationId = null;
@@ -326,6 +326,7 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
+			$barcode = $args['barcode'];
 			if (Grocycode::Validate($barcode))
 			{
 				$gc = new Grocycode($barcode);

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -817,6 +817,18 @@ class StockApiController extends BaseApiController
 		try
 		{
 			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+
+			if (Grocycode::Validate($args['barcode']))
+			{
+				$gc = new Grocycode($args['barcode']);
+				if ($gc->GetExtraData())
+				{
+					$requestBody = $request->getParsedBody();
+					$requestBody['stock_entry_id'] = $gc->GetExtraData()[0];
+					$request = $request->withParsedBody($requestBody);
+				}
+			}
+
 			return $this->TransferProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -282,10 +282,10 @@ class StockApiController extends BaseApiController
 			{
 				$specificStockEntryId = $requestBody['stock_entry_id'];
 			}
-            else if (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
-            {
+			elseif (array_key_exists('stock_id', $args) && !empty($args['stock_id']))
+			{
 				$specificStockEntryId = $args['stock_id'];
-            }
+			}
 
 			$locationId = null;
 			if (array_key_exists('location_id', $requestBody) && !empty($requestBody['location_id']) && is_numeric($requestBody['location_id']))
@@ -326,23 +326,23 @@ class StockApiController extends BaseApiController
 	{
 		try
 		{
-	    if (Grocycode::Validate($barcode))
-	    {
-	        $gc = new Grocycode($barcode);
-	        if ($gc->GetType() != Grocycode::PRODUCT)
-	        {
-	            throw new \Exception("Invalid grocycode type");
-	        }
-	        $args['productId'] = $gc->GetId();
-	        if ($gc->GetExtraData())
-	        {
-	            $args['stock_id'] = $gc->GetExtraData()[0];
-	        }
-	    }
-	    else
-	    {
-	        $args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
-	    }
+			if (Grocycode::Validate($barcode))
+			{
+				$gc = new Grocycode($barcode);
+				if ($gc->GetType() != Grocycode::PRODUCT)
+				{
+					throw new \Exception('Invalid grocycode type');
+				}
+				$args['productId'] = $gc->GetId();
+				if ($gc->GetExtraData())
+				{
+					$args['stock_id'] = $gc->GetExtraData()[0];
+				}
+			}
+			else
+			{
+				$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+			}
 			return $this->ConsumeProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)


### PR DESCRIPTION
if the stock_entry_id is in the request body use this instead of the stockentry grocycode
this may not be the correct way to interpret this but one of them has to win

