### PR TITLE
Fix link to access user settings from the dropdown menu not beeing re…

### DIFF
--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -639,7 +639,7 @@
 							href="{{ $U('/batteriessettings') }}"><i class="fas fa-battery-half"></i>&nbsp;{{ $__t('Batteries settings') }}</a>
 						@endif
 						<div class="dropdown-divider"></div>
-						<a data-href="{{ $U('/usersettings') }}"
+						<a href="{{ $U('/usersettings') }}"
 							class="dropdown-item discrete-link link-return">
 							<i class="fas fa-user-cog"></i> {{ $__t('User settings') }}
 						</a>


### PR DESCRIPTION
…cognized as link by the browsers

Hi, I can't click on the user settings link (using either firefox or falkon) because of the link not being recognized as one (because of the leading data-).

Since others are plain href, I guess it's a typo, so here's a fix.