### PR TITLE
#1596 Fix race condition in shopping list add item workflow

### DIFF
--- a/public/viewjs/shoppinglist.js
+++ b/public/viewjs/shoppinglist.js
@@ -264,10 +264,12 @@ $(document).on('click', '.shopping-list-stock-add-workflow-list-item-button', fu
 Grocy.ShoppingListToStockWorkflowAll = false;
 Grocy.ShoppingListToStockWorkflowCount = 0;
 Grocy.ShoppingListToStockWorkflowCurrent = 0;
+Grocy.ShoppingListAddToStockButtonList = [];
 $(document).on('click', '#add-all-items-to-stock-button', function(e)
 {
 	Grocy.ShoppingListToStockWorkflowAll = true;
-	Grocy.ShoppingListToStockWorkflowCount = $(".shopping-list-stock-add-workflow-list-item-button").length;
+	Grocy.ShoppingListAddToStockButtonList = $(".shopping-list-stock-add-workflow-list-item-button");
+	Grocy.ShoppingListToStockWorkflowCount = Grocy.ShoppingListAddToStockButtonList.length;
 	Grocy.ShoppingListToStockWorkflowCurrent++;
 	$(".shopping-list-stock-add-workflow-list-item-button").first().click();
 });
@@ -277,6 +279,7 @@ $("#shopping-list-stock-add-workflow-modal").on("hidden.bs.modal", function(e)
 	Grocy.ShoppingListToStockWorkflowAll = false;
 	Grocy.ShoppingListToStockWorkflowCount = 0;
 	Grocy.ShoppingListToStockWorkflowCurrent = 0;
+	Grocy.ShoppingListAddToStockButtonList = [];
 })
 
 $(window).on("message", function(e)
@@ -298,7 +301,7 @@ $(window).on("message", function(e)
 			Grocy.ShoppingListToStockWorkflowCurrent++;
 			if (Grocy.ShoppingListToStockWorkflowCurrent <= Grocy.ShoppingListToStockWorkflowCount)
 			{
-				$(".shopping-list-stock-add-workflow-list-item-button")[Grocy.ShoppingListToStockWorkflowCurrent - 1].click();
+				Grocy.ShoppingListAddToStockButtonList[Grocy.ShoppingListToStockWorkflowCurrent - 1].click();
 			}
 			else
 			{


### PR DESCRIPTION
I believe #1596 was caused by the result of `$(".shopping-list-stock-add-workflow-list-item-button")` changing over the course of the workflow. This fix stores a reference to the list of buttons at the start of the workflow and iterates over those, rather than reading in a new list of buttons that is out of sync with the ShoppingListToStockWorkflowCurrent index.