### PR TITLE
Add a setting to treat -1 as singular

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -22,6 +22,9 @@ Setting('MODE', 'production');
 // one of the other available localization folders in the "/localization" directory
 Setting('DEFAULT_LOCALE', 'en');
 
+// For most languages it might be a good idea to treat -1 as singular
+Setting('TREAT_MINUS_ONE_AS_SINGULAR', true);
+
 // This is used to define the first day of a week for calendar views in the frontend,
 // leave empty to use the locale default
 // Needs to be a number where Sunday = 0, Monday = 1 and so forth

--- a/services/LocalizationService.php
+++ b/services/LocalizationService.php
@@ -73,7 +73,7 @@ class LocalizationService
 	{
 		$this->CheckAndAddMissingTranslationToPot($singularForm);
 
-		return sprintf($this->Translator->ngettext($singularForm, $pluralForm, $number), $number);
+		return sprintf($this->Translator->ngettext($singularForm, $pluralForm, GROCY_TREAT_MINUS_ONE_AS_SINGULAR ? abs($number) : $number), $number);
 	}
 
 	public function __t($text, ...$placeholderValues)


### PR DESCRIPTION
To ensure that all languages get always their right singular form
or plural form its better to let the user choice whether '-1' should
be interpreted as singular form.