### PR TITLE
StockLogEntry Property "used_date" is Format date instead of date-time

### DIFF
--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5120,7 +5120,7 @@
 					},
 					"used_date": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"spoiled": {
 						"type": "boolean",


### PR DESCRIPTION
The column "used_date" in "stock_log" is created as Type DATE.

In the grocy.openapi.json File the Property "used_date" of StockLogEntry is mentioned as Type date-time