### PR TITLE
Display ingredients and recipe side by side

### DIFF
--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -654,11 +654,12 @@ canvas.drawingBuffer {
     }
 
     .fullscreen #ingredients-0 {
-        min-width: 20rem;
-        max-width: 20rem;
-    }
-    .fullscreen .nav-link[href="#ingredients-0"] {
         width: 20rem;
+        padding-right: 3rem;
+    }
+
+    .fullscreen .grocy-tabs {
+        display: none;
     }
 
     .fullscreen .tab-content {

--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -645,3 +645,23 @@ canvas.drawingBuffer {
 	pointer-events: none;
 	opacity: 0.5;
 }
+
+@media only screen and (min-width: 60rem) {
+    /* See ingredients and recipe side by side */
+
+    .fullscreen .tab-content > .tab-pane {
+        display: inline;
+    }
+
+    .fullscreen #ingredients-0 {
+        min-width: 20rem;
+        max-width: 20rem;
+    }
+    .fullscreen .nav-link[href="#ingredients-0"] {
+        width: 20rem;
+    }
+
+    .fullscreen .tab-content {
+        display: flex;
+    }
+}


### PR DESCRIPTION
In full screen mode display both the ingredients and the recipe side by
side instead of having to switch between them via the tabs if there is
enough space.