### PR TITLE
Fix printing label per unit

### DIFF
--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -313,11 +313,11 @@ if (Grocy.Components.ProductPicker !== undefined)
 							{
 								$("#default_print_stock_label").val("0");
 							}
-							$('#label-option-per-unit').prop("disabled", true);
+							$('#label-option-per-unit').prop("disabled", false);
 						}
 						else
 						{
-							$('#label-option-per-unit').prop("disabled", false);
+							$('#label-option-per-unit').prop("disabled", true);
 						}
 					}
 


### PR DESCRIPTION
If a product allows label printing per unit, the current code prevents you from setting "stock entry label" to "label per unit" on the purchase page because the option is disabled. Only a single label can be printed.

Even if you set the product default to "label per unit" and don't change it on the purchase page, the selection is ignored because the option is disabled, so `jsonForm.print_stock_label` is undefined. In this case, no labels are printed at all because the value is undefined.

This change enables/disables the option in the correct cases.