### PR TITLE
Replace Timeago with momentjs

### DIFF
--- a/localization/component_translations.pot
+++ b/localization/component_translations.pot
@@ -12,12 +12,6 @@ msgstr ""
 "Language: en\n"
 "X-Domain: grocy/component_translations\n"
 
-msgid "timeago_locale"
-msgstr ""
-
-msgid "timeago_nan"
-msgstr ""
-
 msgid "moment_locale"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"summernote": "^0.8.18",
 		"swagger-ui-dist": "^3.32.1",
 		"tempusdominus-bootstrap-4": "https://github.com/berrnd/tempusdominus-bootstrap-4.git#master",
-		"timeago": "^1.6.7",
 		"toastr": "^2.1.4"
 	},
 	"scripts": {

--- a/public/js/grocy.js
+++ b/public/js/grocy.js
@@ -316,7 +316,6 @@ if (window.localStorage.getItem("sidebar_state") === "collapsed")
 	$("#sidenavToggler").click();
 }
 
-$.timeago.settings.allowFuture = true;
 RefreshContextualTimeago = function(rootSelector = "#page-content")
 {
 	$(rootSelector + " time.timeago").each(function()
@@ -352,7 +351,7 @@ RefreshContextualTimeago = function(rootSelector = "#page-content")
 		}
 		else
 		{
-			element.timeago("update", timestamp);
+			element.text(moment(timestamp).fromNow());
 		}
 
 		if (isDateWithoutTime)

--- a/public/viewjs/components/batterycard.js
+++ b/public/viewjs/components/batterycard.js
@@ -16,7 +16,6 @@ Grocy.Components.BatteryCard.Refresh = function(batteryId)
 			$('#batterycard-battery-edit-button').removeClass("disabled");
 			$('#batterycard-battery-journal-button').removeClass("disabled");
 
-			EmptyElementWhenMatches('#batterycard-battery-last-charged-timeago', __t('timeago_nan'));
 			RefreshContextualTimeago(".batterycard");
 		},
 		function(xhr)

--- a/public/viewjs/components/chorecard.js
+++ b/public/viewjs/components/chorecard.js
@@ -25,7 +25,6 @@ Grocy.Components.ChoreCard.Refresh = function(choreId)
 				$("#chorecard-chore-last-tracked-timeago").removeClass("timeago-date-only");
 			}
 
-			EmptyElementWhenMatches('#chorecard-chore-last-tracked-timeago', __t('timeago_nan'));
 			RefreshContextualTimeago(".chorecard");
 		},
 		function(xhr)

--- a/public/viewjs/components/datetimepicker.js
+++ b/public/viewjs/components/datetimepicker.js
@@ -270,7 +270,6 @@ Grocy.Components.DateTimePicker.GetInputElement().on('keyup', function(e)
 Grocy.Components.DateTimePicker.GetInputElement().on('input', function(e)
 {
 	$('#datetimepicker-timeago').attr("datetime", Grocy.Components.DateTimePicker.GetValue());
-	EmptyElementWhenMatches('#datetimepicker-timeago', __t('timeago_nan'));
 	RefreshContextualTimeago(".datetimepicker-wrapper");
 });
 

--- a/public/viewjs/components/datetimepicker2.js
+++ b/public/viewjs/components/datetimepicker2.js
@@ -270,7 +270,6 @@ Grocy.Components.DateTimePicker2.GetInputElement().on('keyup', function(e)
 Grocy.Components.DateTimePicker2.GetInputElement().on('input', function(e)
 {
 	$('#datetimepicker2-timeago').attr("datetime", Grocy.Components.DateTimePicker2.GetValue());
-	EmptyElementWhenMatches('#datetimepicker2-timeago', __t('timeago_nan'));
 	RefreshContextualTimeago(".datetimepicker2-wrapper");
 });
 

--- a/public/viewjs/components/productcard.js
+++ b/public/viewjs/components/productcard.js
@@ -110,8 +110,6 @@ Grocy.Components.ProductCard.Refresh = function(productId)
 				$("#productcard-product-picture").addClass("d-none");
 			}
 
-			EmptyElementWhenMatches('#productcard-product-last-purchased-timeago', __t('timeago_nan'));
-			EmptyElementWhenMatches('#productcard-product-last-used-timeago', __t('timeago_nan'));
 			RefreshContextualTimeago(".productcard");
 		},
 		function(xhr)

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -697,8 +697,6 @@
 	<script src="{{ $U('/node_modules/datatables.net-rowgroup-bs4/js/rowGroup.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-select/js/dataTables.select.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/datatables.net-select-bs4/js/select.bootstrap4.min.js?v=', true) }}{{ $version }}"></script>
-	<script src="{{ $U('/node_modules/timeago/jquery.timeago.js?v=', true) }}{{ $version }}"></script>
-	<script src="{{ $U('/node_modules', true) }}/timeago/locales/jquery.timeago.{{ $__t('timeago_locale') }}.js?v={{ $version }}"></script>
 	<script src="{{ $U('/node_modules/toastr/build/toastr.min.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/tempusdominus-bootstrap-4/build/js/tempusdominus-bootstrap-4.js?v=', true) }}{{ $version }}"></script>
 	<script src="{{ $U('/node_modules/sprintf-js/dist/sprintf.min.js?v=', true) }}{{ $version }}"></script>

--- a/views/stockentries.blade.php
+++ b/views/stockentries.blade.php
@@ -241,7 +241,7 @@
 						<span id="stock-{{ $stockEntry->id }}-due-date">{{ $stockEntry->best_before_date }}</span>
 						<time id="stock-{{ $stockEntry->id }}-due-date-timeago"
 							class="timeago timeago-contextual"
-							datetime="{{ $stockEntry->best_before_date }} 23:59:59"></time>
+							@if($stockEntry->best_before_date != "") datetime="{{ $stockEntry->best_before_date }} 23:59:59" @endif></time>
 					</td>
 					<td id="stock-{{ $stockEntry->id }}-location"
 						class="@if(!GROCY_FEATURE_FLAG_STOCK_LOCATION_TRACKING) d-none @endif"
@@ -265,7 +265,7 @@
 						<span id="stock-{{ $stockEntry->id }}-purchased-date">{{ $stockEntry->purchased_date }}</span>
 						<time id="stock-{{ $stockEntry->id }}-purchased-date-timeago"
 							class="timeago timeago-contextual"
-							datetime="{{ $stockEntry->purchased_date }} 23:59:59"></time>
+							@if($stockEntry->purchased_date != "") datetime="{{ $stockEntry->purchased_date }} 23:59:59" @endif></time>
 					</td>
 					<td class="d-none">{{ $stockEntry->purchased_date }}</td>
 					<td>

--- a/views/stockentries.blade.php
+++ b/views/stockentries.blade.php
@@ -265,7 +265,7 @@
 						<span id="stock-{{ $stockEntry->id }}-purchased-date">{{ $stockEntry->purchased_date }}</span>
 						<time id="stock-{{ $stockEntry->id }}-purchased-date-timeago"
 							class="timeago timeago-contextual"
-							@if($stockEntry->purchased_date != "") datetime="{{ $stockEntry->purchased_date }} 23:59:59" @endif></time>
+							@if(!empty($stockEntry->purchased_date)) datetime="{{ $stockEntry->purchased_date }} 23:59:59" @endif></time>
 					</td>
 					<td class="d-none">{{ $stockEntry->purchased_date }}</td>
 					<td>

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -352,7 +352,7 @@
 						<span id="product-{{ $currentStockEntry->product_id }}-next-due-date">{{ $currentStockEntry->best_before_date }}</span>
 						<time id="product-{{ $currentStockEntry->product_id }}-next-due-date-timeago"
 							class="timeago timeago-contextual"
-							datetime="{{ $currentStockEntry->best_before_date }} 23:59:59"></time>
+							@if($currentStockEntry->best_before_date != "") datetime="{{ $currentStockEntry->best_before_date }} 23:59:59" @endif></time>
 					</td>
 					<td class="d-none">
 						@foreach(FindAllObjectsInArrayByPropertyValue($currentStockLocations, 'product_id', $currentStockEntry->product_id) as $locationsForProduct)

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -352,7 +352,7 @@
 						<span id="product-{{ $currentStockEntry->product_id }}-next-due-date">{{ $currentStockEntry->best_before_date }}</span>
 						<time id="product-{{ $currentStockEntry->product_id }}-next-due-date-timeago"
 							class="timeago timeago-contextual"
-							@if($currentStockEntry->best_before_date != "") datetime="{{ $currentStockEntry->best_before_date }} 23:59:59" @endif></time>
+							@if(!empty($currentStockEntry->best_before_date)) datetime="{{ $currentStockEntry->best_before_date }} 23:59:59" @endif></time>
 					</td>
 					<td class="d-none">
 						@foreach(FindAllObjectsInArrayByPropertyValue($currentStockLocations, 'product_id', $currentStockEntry->product_id) as $locationsForProduct)

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,7 +498,7 @@ jquery@3.5.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
-jquery@>=1.12.0, "jquery@>=1.5.0 <4.0", jquery@>=1.7, jquery@>=1.7.2, jquery@^3.0, jquery@^3.5.1:
+jquery@>=1.12.0, jquery@>=1.7, jquery@>=1.7.2, jquery@^3.0, jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
@@ -742,13 +742,6 @@ through@^2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-timeago@^1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/timeago/-/timeago-1.6.7.tgz#afd467c29a911e697fc22a81888c7c3022783cb5"
-  integrity sha512-FikcjN98+ij0siKH4VO4dZ358PR3oDDq4Vdl1+sN9gWz1/+JXGr3uZbUShYH/hL7bMhcTpPbplJU5Tej4b4jbQ==
-  dependencies:
-    jquery ">=1.5.0 <4.0"
 
 toastr@^2.1.4:
   version "2.1.4"


### PR DESCRIPTION
As described in #1685 fuzzy time display is incorrect in Hungarian (and possibly other languages). This PR replaces the timeago package with momentjs inbuilt functionality `fromNow()`.

I also fixed an issue with the relevant table rows where the blade template set the datetime to ` 23:59:59` when no date was provided for the `best_before_date` or `purchased_date` fields. This resulted in an invalid date.

This is my first PR for this repo, please advise if I missed anything or if I should check other things as well.