### PR TITLE
Improve sorting for stock entries view

### DIFF
--- a/public/viewjs/stockentries.js
+++ b/public/viewjs/stockentries.js
@@ -3,7 +3,13 @@
 	'columnDefs': [
 		{ 'orderable': false, 'targets': 0 },
 		{ 'searchable': false, "targets": 0 },
-		{ 'visible': false, 'targets': 10 }
+		{ 'visible': false, 'targets': 10 },
+		{ "type": "num", "targets": 1},
+		{ "type": "num", "targets": 3 },
+		{ "type": "html", "targets": 4 },
+		{ "type": "html-num-fmt", "targets": 7},
+		{ "type": "html", "targets": 8},
+		{ "type": "html", "targets": 9}
 	].concat($.fn.dataTable.defaults.columnDefs)
 });
 $('#stockentries-table tbody').removeClass("d-none");

--- a/views/stockentries.blade.php
+++ b/views/stockentries.blade.php
@@ -231,7 +231,7 @@
 						data-product-id="{{ $stockEntry->product_id }}">
 						{{ FindObjectInArrayByPropertyValue($products, 'id', $stockEntry->product_id)->name }}
 					</td>
-					<td>
+					<td data-order="{{ $stockEntry->amount }}">
 						<span id="stock-{{ $stockEntry->id }}-amount"
 							class="locale-number locale-number-quantity-amount">{{ $stockEntry->amount }}</span> <span id="product-{{ $stockEntry->product_id }}-qu-name">{{ $__n($stockEntry->amount, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $stockEntry->product_id)->qu_id_stock)->name, FindObjectInArrayByPropertyValue($quantityunits, 'id', FindObjectInArrayByPropertyValue($products, 'id', $stockEntry->product_id)->qu_id_stock)->name_plural) }}</span>
 						<span id="stock-{{ $stockEntry->id }}-opened-amount"


### PR DESCRIPTION
In the stockentries view the ordering by expiration date, amount, price
and purchase date did not work as expected. b5fc64cf already addressed a
similar issue for other views. This commit now does the same: set
DataTables types on the specific columns.

Since the units being part of the "amount" column break numeric sorting,
this commit adds a "data-order" field for that column, so numeric
sorting can still work. This is done in aligment with the stockoverview
page, that already contains such an entry to facilitate proper sorting.