### PR TITLE
Added support for reading auth header from env variable

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -76,6 +76,8 @@ Setting('AUTH_CLASS', 'Grocy\Middleware\DefaultAuthMiddleware');
 // When using ReverseProxyAuthMiddleware,
 // the name of the HTTP header which your reverse proxy uses to pass the username (on successful authentication)
 Setting('REVERSE_PROXY_AUTH_HEADER', 'REMOTE_USER');
+// When using ReverseProxyAuthMiddleware, set to true if the username is passed as environment variable
+Setting('REVERSE_PROXY_AUTH_USE_ENV', false);
 
 // LDAP options when using LdapAuthMiddleware
 Setting('LDAP_ADDRESS', ''); // Example value "ldap://vm-dc2019.local.berrnd.net"

--- a/middleware/ReverseProxyAuthMiddleware.php
+++ b/middleware/ReverseProxyAuthMiddleware.php
@@ -24,12 +24,19 @@ class ReverseProxyAuthMiddleware extends AuthMiddleware
 
 		if (GROCY_REVERSE_PROXY_AUTH_USE_ENV)
 		{
+			if (!isset($_SERVER[GROCY_REVERSE_PROXY_AUTH_HEADER]))
+			{
+				// Variable is not set
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' env variable is missing, could not be found in $_SERVER array.');
+			}
+			
 			$username = $_SERVER[GROCY_REVERSE_PROXY_AUTH_HEADER];
 			if (strlen($username) === 0)
 			{
-				// Invalid configuration of Proxy
-				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing or invalid');
+				// Variable is empty
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' env variable is invalid');
 			}
+			
 		} else {
 			$username = $request->getHeader(GROCY_REVERSE_PROXY_AUTH_HEADER);
 			if (count($username) !== 1)

--- a/middleware/ReverseProxyAuthMiddleware.php
+++ b/middleware/ReverseProxyAuthMiddleware.php
@@ -27,17 +27,18 @@ class ReverseProxyAuthMiddleware extends AuthMiddleware
 			if (!isset($_SERVER[GROCY_REVERSE_PROXY_AUTH_HEADER]))
 			{
 				// Variable is not set
-				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' env variable is missing, could not be found in $_SERVER array.');
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' env variable is missing (could not be found in $_SERVER array)');
 			}
-			
+
 			$username = $_SERVER[GROCY_REVERSE_PROXY_AUTH_HEADER];
 			if (strlen($username) === 0)
 			{
 				// Variable is empty
 				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' env variable is invalid');
 			}
-			
-		} else {
+		}
+		else
+		{
 			$username = $request->getHeader(GROCY_REVERSE_PROXY_AUTH_HEADER);
 			if (count($username) !== 1)
 			{
@@ -46,8 +47,6 @@ class ReverseProxyAuthMiddleware extends AuthMiddleware
 			}
 			$username = $username[0];
 		}
-		
-		
 
 		$user = $db->users()->where('username', $username)->fetch();
 		if ($user == null)

--- a/middleware/ReverseProxyAuthMiddleware.php
+++ b/middleware/ReverseProxyAuthMiddleware.php
@@ -22,13 +22,25 @@ class ReverseProxyAuthMiddleware extends AuthMiddleware
 			return $user;
 		}
 
-		$username = $request->getHeader(GROCY_REVERSE_PROXY_AUTH_HEADER);
-		if (count($username) !== 1)
+		if (GROCY_REVERSE_PROXY_AUTH_USE_ENV)
 		{
-			// Invalid configuration of Proxy
-			throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing or invalid');
+			$username = $_SERVER[GROCY_REVERSE_PROXY_AUTH_HEADER];
+			if (strlen($username) === 0)
+			{
+				// Invalid configuration of Proxy
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing or invalid');
+			}
+		} else {
+			$username = $request->getHeader(GROCY_REVERSE_PROXY_AUTH_HEADER);
+			if (count($username) !== 1)
+			{
+				// Invalid configuration of Proxy
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing or invalid');
+			}
+			$username = $username[0];
 		}
-		$username = $username[0];
+		
+		
 
 		$user = $db->users()->where('username', $username)->fetch();
 		if ($user == null)


### PR DESCRIPTION
This is a modification for ReverseProxyAuthMiddleware in order to support server env variables.

These are more secure than regular headers. An example for authelia running behind nginx would be:

```
       [...]
    server_name grocy.yourserver
    include snippets/authelia.conf;
    location / {
            include snippets/auth.conf;
            try_files $uri /index.php;
       }

    location ~ \.php$ {
        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
        include        fastcgi_params;
             
        fastcgi_param REMOTE_USER $user;
        fastcgi_param REMOTE_GROUPS $groups;

        fastcgi_param  PATH_INFO        $path_info;
        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
    }
```

In this case `fastcgi_param REMOTE_USER $user;` would set the env variable REMOTE_USER with the logged in user name
