### PR TITLE
fix: can't print in landscape

### DIFF
--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -650,13 +650,13 @@ canvas.drawingBuffer {
 	.calendar button.fc-agendaDay-button {
 		display: none;
 	}
+
+	@page {
+		size: auto
+	}
 }
 
 .not-allowed {
 	pointer-events: none;
 	opacity: 0.5;
-}
-
-@page {
-	size: auto
 }

--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -656,3 +656,7 @@ canvas.drawingBuffer {
 	pointer-events: none;
 	opacity: 0.5;
 }
+
+@page {
+	size: auto
+}


### PR DESCRIPTION
Layout settings are hidden in the print dialog when printing a page like the mealplan.
Bootstrap 4 bug https://github.com/twbs/bootstrap/issues/25629