### PR TITLE
Handle stock_id in OpenProductByBarcode

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -584,9 +584,11 @@ class StockApiController extends BaseApiController
 		{
 			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
 
-			if (Grocycode::Validate($args['barcode'])) {
+			if (Grocycode::Validate($args['barcode']))
+			{
 				$gc = new Grocycode($args['barcode']);
-				if ($gc->GetExtraData()) {
+				if ($gc->GetExtraData())
+				{
 					$requestBody = $request->getParsedBody();
 					$requestBody['stock_entry_id'] = $gc->GetExtraData()[0];
 					$request = $request->withParsedBody($requestBody);

--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -583,6 +583,16 @@ class StockApiController extends BaseApiController
 		try
 		{
 			$args['productId'] = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
+
+			if (Grocycode::Validate($args['barcode'])) {
+				$gc = new Grocycode($args['barcode']);
+				if ($gc->GetExtraData()) {
+					$requestBody = $request->getParsedBody();
+					$requestBody['stock_entry_id'] = $gc->GetExtraData()[0];
+					$request = $request->withParsedBody($requestBody);
+				}
+			}
+
 			return $this->OpenProduct($request, $response, $args);
 		}
 		catch (\Exception $ex)


### PR DESCRIPTION
While playing around with the API, I realised that /stock/products/by-barcode/:grocycode/open (OpenProductByBarcode) ignores the stock_id provided in the barcode.

But [ConsumeProductByBarcode](https://github.com/grocy/grocy/blob/af7de61c43e250bf03f1a3209e96c19c5efa9e9e/controllers/StockApiController.php#L327) does respect the stock_id.

So I compared both functions and adapted OpenProductByBarcode to mimic ConsumeProductByBarcode.

I tested the API afterwards and it works as expected