### PR TITLE
Add support for transitive unit conversions

### DIFF
--- a/migrations/0203.sql
+++ b/migrations/0203.sql
@@ -1,0 +1,129 @@
+DROP VIEW IF EXISTS quantity_unit_conversions_resolved;
+
+CREATE VIEW quantity_unit_conversions_resolved AS
+WITH RECURSIVE
+	single(product_id, from_qu_id, to_qu_id, factor, source)
+AS (
+	-- 1. Product "purchase to stock" conversion factor
+	SELECT
+		p.id AS product_id,
+		p.qu_id_purchase AS from_qu_id,
+		p.qu_id_stock AS to_qu_id,
+		CASE WHEN p.qu_id_stock = p.qu_id_purchase THEN 1.0 ELSE p.qu_factor_purchase_to_stock END AS factor, -- Enforce a factor of 1 when QU stock = QU purchase
+		'1 product purchase to stock factor' AS source
+	FROM products p
+	UNION -- Inversed
+	SELECT
+		p.id AS product_id,
+		p.qu_id_stock AS from_qu_id,
+		p.qu_id_purchase AS to_qu_id,
+		1 / p.qu_factor_purchase_to_stock AS factor,
+		'1 product purchase to stock factor (inversed)' AS source
+	FROM products p
+	WHERE p.qu_id_stock != p.qu_id_purchase -- => Only when QU stock is not the same as QU purchase
+
+	UNION
+
+	-- 2. Product specific QU overrides
+	SELECT
+		p.id AS product_id,
+		quc.from_qu_id AS from_qu_id,
+		quc.to_qu_id AS to_qu_id,
+		quc.factor AS factor,
+		'2 product override' AS source
+	FROM products p
+	JOIN quantity_unit_conversions quc
+		ON p.id = quc.product_id
+
+	UNION
+
+	-- 3. Default (direct) QU conversion factors
+	SELECT
+		p.id AS product_id,
+		p.qu_id_stock AS from_qu_id,
+		quc.to_qu_id AS to_qu_id,
+		quc.factor AS factor,
+		'3 default direct factor' AS source
+	FROM products p
+	JOIN quantity_unit_conversions quc
+		ON p.qu_id_stock = quc.from_qu_id
+		AND quc.product_id IS NULL
+	JOIN quantity_units qu_from
+		ON quc.from_qu_id = qu_from.id
+	JOIN quantity_units qu_to
+		ON quc.to_qu_id = qu_to.id
+
+	UNION
+
+	-- 4. Default (indirect) QU conversion factors
+	SELECT
+		p.id AS product_id,
+		(SELECT from_qu_id FROM quantity_unit_conversions WHERE to_qu_id = quc.to_qu_id AND product_id = p.id) AS from_qu_id,
+		quc.from_qu_id AS to_qu_id,
+		(SELECT factor FROM quantity_unit_conversions WHERE to_qu_id = quc.to_qu_id AND product_id = p.id) / quc.factor AS factor,
+		'4 default indirect factor' AS source
+	FROM products p
+	JOIN product_qu_relations pqr
+		ON p.id = pqr.product_id
+	JOIN quantity_unit_conversions quc
+		ON pqr.qu_id = quc.from_qu_id
+		AND quc.product_id IS NULL
+	WHERE NOT EXISTS(SELECT 1 FROM quantity_unit_conversions qucx WHERE qucx.product_id = p.id AND qucx.from_qu_id = pqr.qu_id) -- => Product override exists
+),
+	closure(depth, product_id, path, from_qu_id, to_qu_id, factor, source)
+AS (
+	SELECT
+		1 as depth, product_id,
+		-- We need to keep track of the conversion path in order to prevent infinite loops
+		'/' || from_qu_id || '/' || to_qu_id || '/',
+		from_qu_id, to_qu_id,
+		factor, source
+	FROM single
+	
+	UNION
+	
+	SELECT
+		c.depth + 1, c.product_id,
+		c.path || s.to_qu_id || '/',
+		c.from_qu_id, s.to_qu_id,
+		c.factor * s.factor,
+		c.source || ' ~~> ' || s.source
+	FROM closure c
+	JOIN single s
+		ON  c.product_id = s.product_id
+		AND c.to_qu_id = s.from_qu_id
+	WHERE
+		c.path NOT LIKE ('%/' || s.to_qu_id || '/%')
+),
+	closure_rn(row_num, product_id, from_qu_id, to_qu_id, factor, source)
+AS (
+	SELECT
+		ROW_NUMBER() OVER(PARTITION BY product_id, from_qu_id, to_qu_id ORDER BY depth ASC),
+		product_id,
+		from_qu_id,
+		to_qu_id,
+		factor,
+		source
+	FROM closure
+)
+
+SELECT DISTINCT
+	-1 AS id, -- Dummy, LessQL needs an id column
+	c.product_id,
+	c.from_qu_id,
+	qu_from.name AS from_qu_name,
+	qu_from.name_plural AS from_qu_name_plural,
+	c.to_qu_id,
+	qu_to.name AS to_qu_name,
+	qu_to.name_plural AS to_qu_name_plural,
+	factor,
+	source
+FROM closure_rn c
+	JOIN quantity_units qu_from
+		ON c.from_qu_id = qu_from.id
+	JOIN quantity_units qu_to
+		ON c.to_qu_id = qu_to.id
+WHERE
+	c.row_num = 1
+ORDER BY
+	product_id, from_qu_id, to_qu_id;

--- a/migrations/0203.sql
+++ b/migrations/0203.sql
@@ -2,128 +2,145 @@ DROP VIEW IF EXISTS quantity_unit_conversions_resolved;
 
 CREATE VIEW quantity_unit_conversions_resolved AS
 WITH RECURSIVE
-	single(product_id, from_qu_id, to_qu_id, factor, source)
+
+-- First, determine conversions that are a single step.
+-- There may be multiple definitions for conversions between two units
+-- (e.g. due to purchase-to-stock, product-specific and default conversions),
+-- thus priorities are used to disambiguate conversions.
+-- Later, we'll only use the factor with the highest priority to convert between two units.
+
+	conversion_factors_dup(product_id, from_qu_id, to_qu_id, factor, priority)
 AS (
-	-- 1. Product "purchase to stock" conversion factor
+	-- 1. Product "purchase to stock" factors ...
 	SELECT
-		p.id AS product_id,
-		p.qu_id_purchase AS from_qu_id,
-		p.qu_id_stock AS to_qu_id,
-		CASE WHEN p.qu_id_stock = p.qu_id_purchase THEN 1.0 ELSE p.qu_factor_purchase_to_stock END AS factor, -- Enforce a factor of 1 when QU stock = QU purchase
-		'1 product purchase to stock factor' AS source
+		p.id, p.qu_id_purchase, p.qu_id_stock, p.qu_factor_purchase_to_stock, 50
 	FROM products p
-	UNION -- Inversed
+	WHERE p.qu_id_stock != p.qu_id_purchase
+	UNION
+	-- ... and the inverse factors
 	SELECT
-		p.id AS product_id,
-		p.qu_id_stock AS from_qu_id,
-		p.qu_id_purchase AS to_qu_id,
-		1 / p.qu_factor_purchase_to_stock AS factor,
-		'1 product purchase to stock factor (inversed)' AS source
+		p.id, p.qu_id_stock, p.qu_id_purchase, 1.0 / p.qu_factor_purchase_to_stock, 50
 	FROM products p
-	WHERE p.qu_id_stock != p.qu_id_purchase -- => Only when QU stock is not the same as QU purchase
+	WHERE p.qu_id_stock != p.qu_id_purchase
 
 	UNION
 
 	-- 2. Product specific QU overrides
+	-- Note that the quantity_unit_conversions table already contains both conversion directions for every conversion.
 	SELECT
-		p.id AS product_id,
-		quc.from_qu_id AS from_qu_id,
-		quc.to_qu_id AS to_qu_id,
-		quc.factor AS factor,
-		'2 product override' AS source
-	FROM products p
-	JOIN quantity_unit_conversions quc
-		ON p.id = quc.product_id
+		product_id, from_qu_id, to_qu_id, factor, 30
+	FROM quantity_unit_conversions
+	WHERE product_id IS NOT NULL
 
 	UNION
 
-	-- 3. Default (direct) QU conversion factors
+	-- 3. Default QU conversions are handled in a later CTE, as we can't determine yet, for which products they are
+	-- applicable.
 	SELECT
-		p.id AS product_id,
-		p.qu_id_stock AS from_qu_id,
-		quc.to_qu_id AS to_qu_id,
-		quc.factor AS factor,
-		'3 default direct factor' AS source
-	FROM products p
-	JOIN quantity_unit_conversions quc
-		ON p.qu_id_stock = quc.from_qu_id
-		AND quc.product_id IS NULL
-	JOIN quantity_units qu_from
-		ON quc.from_qu_id = qu_from.id
-	JOIN quantity_units qu_to
-		ON quc.to_qu_id = qu_to.id
-
-	UNION
-
-	-- 4. Default (indirect) QU conversion factors
-	SELECT
-		p.id AS product_id,
-		(SELECT from_qu_id FROM quantity_unit_conversions WHERE to_qu_id = quc.to_qu_id AND product_id = p.id) AS from_qu_id,
-		quc.from_qu_id AS to_qu_id,
-		(SELECT factor FROM quantity_unit_conversions WHERE to_qu_id = quc.to_qu_id AND product_id = p.id) / quc.factor AS factor,
-		'4 default indirect factor' AS source
-	FROM products p
-	JOIN product_qu_relations pqr
-		ON p.id = pqr.product_id
-	JOIN quantity_unit_conversions quc
-		ON pqr.qu_id = quc.from_qu_id
-		AND quc.product_id IS NULL
-	WHERE NOT EXISTS(SELECT 1 FROM quantity_unit_conversions qucx WHERE qucx.product_id = p.id AND qucx.from_qu_id = pqr.qu_id) -- => Product override exists
+		product_id, from_qu_id, to_qu_id, factor, 10
+	FROM quantity_unit_conversions
+	WHERE product_id IS NULL
 ),
-	closure(depth, product_id, path, from_qu_id, to_qu_id, factor, source)
+
+-- Now, remove duplicate conversions, only retaining the entries with the highest priority
+	conversion_factors(product_id, from_qu_id, to_qu_id, factor)
 AS (
+	SELECT product_id, from_qu_id, to_qu_id,
+	       first_value(factor) OVER win
+	FROM conversion_factors_dup
+	GROUP BY product_id, from_qu_id, to_qu_id
+	WINDOW win AS (PARTITION BY product_id, from_qu_id, to_qu_id ORDER BY priority DESC)
+),
+
+-- Now build the closure of posisble conversions using a recursive CTE
+	closure(depth, product_id, path, from_qu_id, to_qu_id, factor)
+AS (
+	-- As a base case, select the conversions that refer to a concrete product
 	SELECT
 		1 as depth, product_id,
-		-- We need to keep track of the conversion path in order to prevent infinite loops
+		-- We need to keep track of the conversion path in order to prevent cycles
 		'/' || from_qu_id || '/' || to_qu_id || '/',
-		from_qu_id, to_qu_id,
-		factor, source
-	FROM single
-	
+		from_qu_id, to_qu_id, factor
+	FROM conversion_factors
+	WHERE product_id IS NOT NULL
+
 	UNION
-	
+
+	-- First recursive case: Add a product-associated conversion to the chain
 	SELECT
 		c.depth + 1, c.product_id,
 		c.path || s.to_qu_id || '/',
 		c.from_qu_id, s.to_qu_id,
-		c.factor * s.factor,
-		c.source || ' ~~> ' || s.source
+		c.factor * s.factor
 	FROM closure c
-	JOIN single s
-		ON  c.product_id = s.product_id
+	JOIN conversion_factors s
+		ON  c.product_id = s.product_id -- c.product_id IS NOT NULL
 		AND c.to_qu_id = s.from_qu_id
-	WHERE
-		c.path NOT LIKE ('%/' || s.to_qu_id || '/%')
-),
-	closure_rn(row_num, product_id, from_qu_id, to_qu_id, factor, source)
-AS (
+	WHERE c.path NOT LIKE ('%/' || s.to_qu_id || '/%') -- prevent cycles
+
+	UNION
+
+	-- Second recursive case: Add a default unit conversion to the *start* of the conversion chain
 	SELECT
-		ROW_NUMBER() OVER(PARTITION BY product_id, from_qu_id, to_qu_id ORDER BY depth ASC),
-		product_id,
-		from_qu_id,
-		to_qu_id,
-		factor,
-		source
-	FROM closure
+		c.depth + 1, c.product_id,
+		'/' || s.from_qu_id || c.path,
+		s.from_qu_id, c.to_qu_id,
+		s.factor * c.factor
+	FROM closure c
+	JOIN conversion_factors s
+		ON  s.to_qu_id = c.from_qu_id
+		AND s.product_id IS NULL
+	-- Do this only, if there is no product_specific conversion between the units in s
+	WHERE   NOT EXISTS(SELECT 1 FROM conversion_factors ci WHERE ci.product_id = c.product_id AND ci.from_qu_id = s.from_qu_id AND ci.to_qu_id = s.to_qu_id)
+		AND c.path NOT LIKE ('%/' || s.from_qu_id || '/%')
+
+	UNION
+
+	-- Third recursive case: Add a default unit conversion to the *end* of the conversion chain
+	SELECT
+		c.depth + 1, c.product_id,
+		c.path || s.to_qu_id || '/',
+		c.from_qu_id, s.to_qu_id,
+		c.factor * s.factor
+	FROM closure c
+	JOIN conversion_factors s
+		ON  c.to_qu_id = s.from_qu_id
+		AND s.product_id IS NULL
+	-- Do this only, if there is no product_specific conversion between the units in s
+	WHERE   NOT EXISTS(SELECT 1 FROM conversion_factors ci WHERE ci.product_id = c.product_id AND ci.from_qu_id = s.from_qu_id AND ci.to_qu_id = s.to_qu_id)
+		AND c.path NOT LIKE ('%/' || s.to_qu_id || '/%')
+
+	UNION
+
+	-- Fourth case: Add the default unit conversions that are reachable by a given product.
+	-- We cannot start with them directly, as we only want to add default conversions,
+	-- where at least one of the units is 'reachable' from the product's storage quantity unit.
+	-- Thus we add these cases here.
+	SELECT DISTINCT
+		1, c.product_id,
+		'/' || s.from_qu_id || '/' || s.to_qu_id || '/',
+		s.from_qu_id, s.to_qu_id,
+		s.factor
+	FROM closure c, conversion_factors s
+	WHERE   NOT EXISTS(SELECT 1 FROM conversion_factors ci WHERE ci.product_id = c.product_id AND ci.from_qu_id = s.from_qu_id AND ci.to_qu_id = s.to_qu_id)
+		AND c.path LIKE ('%/' || s.from_qu_id || '/' || s.to_qu_id || '/%')
 )
 
 SELECT DISTINCT
 	-1 AS id, -- Dummy, LessQL needs an id column
 	c.product_id,
 	c.from_qu_id,
-	qu_from.name AS from_qu_name,
+	qu_from.name        AS from_qu_name,
 	qu_from.name_plural AS from_qu_name_plural,
 	c.to_qu_id,
-	qu_to.name AS to_qu_name,
-	qu_to.name_plural AS to_qu_name_plural,
-	factor,
-	source
-FROM closure_rn c
+	qu_to.name          AS to_qu_name,
+	qu_to.name_plural   AS to_qu_name_plural,
+	first_value(factor) OVER (PARTITION BY product_id, from_qu_id, to_qu_id ORDER BY depth ASC) AS factor,
+	c.path              AS source
+FROM closure c
 	JOIN quantity_units qu_from
 		ON c.from_qu_id = qu_from.id
 	JOIN quantity_units qu_to
 		ON c.to_qu_id = qu_to.id
-WHERE
-	c.row_num = 1
 ORDER BY
 	product_id, from_qu_id, to_qu_id;


### PR DESCRIPTION
As discussed in #2039, here's a WIP pull request that adds support for transitive unit conversions to grocy.

When using it, I noticed that floating point inaccuracies may arise.
E.g. referring to the conversions defined in #2039, instead of `2 TL`, the UI will ` 1.9999 TL`.
However, this likely would have happened for a single conversion as well, depending on the factors, as the recipe ingredients are stored internally in the storage unit (?).

Regarding the query, I tried to keep the original one mostly the same and put it in the `single` CTE.
However, I removed the joins with the `quantity_units` table, as those were only used for the names and not relevant for the calculations, and moved them to the final `SELECT`.

When writing this, I thought that the `source` column mostly serves as a kind of debugging help.
I am inclined to remove the `source` column from the final result and possibly also remove it completely, if that's okay for you.
From the query in https://github.com/grocy/grocy/issues/2039#issuecomment-1336116371 I gathered, that this may be used for some sort of disambiguation of conversions, but this could be used to the `closure` CTE (and then the `LIMIT` would not be necessary anymore).