### PR TITLE
Update config docs-in-comment for BASE_URL.

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -53,7 +53,7 @@ Setting('CURRENCY', 'USD');
 Setting('BASE_PATH', '');
 
 // The base URL of your installation,
-// should be just "/" when running directly under the root of a (sub)domain
+// should end in "/" when running directly under the root of a (sub)domain
 // or for example "https://example.com/grocy" when using a subdirectory
 Setting('BASE_URL', '/');
 


### PR DESCRIPTION
I'm running Grocy in Docker behind a reverse proxy, and when looking to adjust the URL so I wasn't redirected to `localhost`, I skipped over this setting at first because of the edited language.

Please consider this a starting point. I didn't want to overstep, but I think this could be adjusted further to explain that this value should be the protocol and domain Grocy is hosted at.