### PR TITLE
Add reference to PikaPods service

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See the website for a list of community contributed Add-ons / Tools. &rarr; [htt
 > Checkout [grocy-desktop](https://github.com/grocy/grocy-desktop), if you want to run Grocy without having to manage a webserver just like a normal (Windows) desktop application.
 >
 > Directly download the [latest release](https://releases.grocy.info/latest-desktop) - the installation is nothing more than just clicking 2 times "next".
+>
+> Grocy's web app is also available on [PikaPods](https://www.pikapods.com/pods?run=grocy) for 1-click deployment. Includes regular updates, EU and US regions, backups and your own domain.
 
 See the website for some installation guides and troubleshooting help. &rarr; [https://grocy.info/links](https://grocy.info/links)
 


### PR DESCRIPTION
Hi there,

Over at [PikaPods.com](https://www.pikapods.com/), we are on a mission to make great open source apps, like Grocy more accessible and simpler to get started with. Since many of our users have [requested](https://feedback.pikapods.com/posts/126/add-app-grocy) the app, it's now available for simple 1-click deployment.

Hope this helps more people find and use the app. We also featured it in our newsletter this  month.

This PR would also add a reference to PikaPods, as additional install option for people who want to use the web app, but don't manage their own server. This would help an even wider audience to benefit from the project.

We are also big on open source sustainability and offer a revenue share with authors to support continued development. We can discuss this in a few weeks, once we have a better idea of the user numbers.

Looking forward to hearing the team’s opinion on this. Thanks for the consideration!

Manu, founder