### PR TITLE
stock_current view now uses cached QUCs -> Recipes consume 50% faster

### DIFF
--- a/migrations/0233.sql
+++ b/migrations/0233.sql
@@ -1,0 +1,51 @@
+DROP VIEW IF EXISTS "main"."stock_current";
+CREATE VIEW stock_current
+AS
+SELECT
+	pr.parent_product_id AS product_id,
+	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id), 0) AS amount,
+	SUM(s.amount * IFNULL(qucr.factor, 1.0)) AS amount_aggregated,
+	IFNULL(ROUND((SELECT SUM(IFNULL(price,0) * amount) FROM stock WHERE product_id = pr.parent_product_id), 2), 0)  AS value,
+	MIN(s.best_before_date) AS best_before_date,
+	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id AND open = 1), 0) AS amount_opened,
+	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id IN (SELECT sub_product_id FROM products_resolved WHERE parent_product_id = pr.parent_product_id) AND open = 1), 0) * IFNULL(qucr.factor, 1) AS amount_opened_aggregated,
+    CASE WHEN COUNT(p_sub.parent_product_id) > 0  THEN 1 ELSE 0 END AS is_aggregated_amount,
+	MAX(p_parent.due_type) AS due_type
+FROM products_resolved pr
+JOIN stock s
+	ON pr.sub_product_id = s.product_id
+JOIN products p_parent
+	ON pr.parent_product_id = p_parent.id
+	AND p_parent.active = 1
+JOIN products p_sub
+	ON pr.sub_product_id = p_sub.id
+	AND p_sub.active = 1
+LEFT JOIN cache__quantity_unit_conversions_resolved qucr
+	ON pr.sub_product_id = qucr.product_id
+	AND p_sub.qu_id_stock = qucr.from_qu_id
+	AND p_parent.qu_id_stock = qucr.to_qu_id
+GROUP BY pr.parent_product_id
+HAVING SUM(s.amount) > 0
+
+UNION
+
+-- This is the same as above but sub products not rolled up (no QU conversion and column is_aggregated_amount = 0 here)
+SELECT
+	pr.sub_product_id AS product_id,
+	SUM(s.amount) AS amount,
+	SUM(s.amount) AS amount_aggregated,
+	ROUND(SUM(IFNULL(s.price, 0) * s.amount), 2) AS value,
+	MIN(s.best_before_date) AS best_before_date,
+	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = s.product_id AND open = 1), 0) AS amount_opened,
+	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = s.product_id AND open = 1), 0) AS amount_opened_aggregated,
+	0 AS is_aggregated_amount,
+	MAX(p_sub.due_type) AS due_type
+FROM products_resolved pr
+JOIN stock s
+	ON pr.sub_product_id = s.product_id
+JOIN products p_sub
+	ON pr.sub_product_id = p_sub.id
+	AND p_sub.active = 1
+WHERE pr.parent_product_id != pr.sub_product_id
+GROUP BY pr.sub_product_id
+HAVING SUM(s.amount) > 0

--- a/migrations/0233.sql
+++ b/migrations/0233.sql
@@ -1,4 +1,4 @@
-DROP VIEW IF EXISTS "main"."stock_current";
+DROP VIEW stock_current;
 CREATE VIEW stock_current
 AS
 SELECT
@@ -9,7 +9,7 @@ SELECT
 	MIN(s.best_before_date) AS best_before_date,
 	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id AND open = 1), 0) AS amount_opened,
 	IFNULL((SELECT SUM(amount) FROM stock WHERE product_id IN (SELECT sub_product_id FROM products_resolved WHERE parent_product_id = pr.parent_product_id) AND open = 1), 0) * IFNULL(qucr.factor, 1) AS amount_opened_aggregated,
-    CASE WHEN COUNT(p_sub.parent_product_id) > 0  THEN 1 ELSE 0 END AS is_aggregated_amount,
+	CASE WHEN COUNT(p_sub.parent_product_id) > 0  THEN 1 ELSE 0 END AS is_aggregated_amount,
 	MAX(p_parent.due_type) AS due_type
 FROM products_resolved pr
 JOIN stock s
@@ -48,4 +48,4 @@ JOIN products p_sub
 	AND p_sub.active = 1
 WHERE pr.parent_product_id != pr.sub_product_id
 GROUP BY pr.sub_product_id
-HAVING SUM(s.amount) > 0
+HAVING SUM(s.amount) > 0;


### PR DESCRIPTION
During the release of the cache__quantity_unit_conversions_resolved the change on the stock_current view was left out.