### PR TITLE
Fix moment locale for zh_CN

### DIFF
--- a/localization/zh_CN/component_translations.po
+++ b/localization/zh_CN/component_translations.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # milkfish <i@mxd.moe>, 2020
 # ba X <985096998@qq.com>, 2020
 # Bernd Bestel <bernd@berrnd.de>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -20,7 +20,7 @@ msgstr ""
 "X-Domain: grocy/component_translations\n"
 
 msgid "moment_locale"
-msgstr "zh-CN"
+msgstr "zh-cn"
 
 msgid "datatables_localization"
 msgstr ""


### PR DESCRIPTION
	
 ```
GET	    https://grocy.some-private-domain.sbs/packages/moment/locale/zh-CN.js?v=4.0.3
状态    404    Not Found
```

```
GET	    https://grocy.some-private-domain.sbs/packages/moment/locale/zh-cn.js?v=4.0.3
状态    200    OK
```