### PR TITLE
Fix typo ('specifc' → 'specific')

### DIFF
--- a/localization/ca/strings.po
+++ b/localization/ca/strings.po
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/cs/strings.po
+++ b/localization/cs/strings.po
@@ -2737,7 +2737,7 @@ msgstr "Zobrazit všechny převody"
 msgid "QU conversions resolved"
 msgstr "Všechny převody měrných jednotek pro"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Převody měrných jednotek pro tento produkt"
 
 msgid "Default quantity unit consume"

--- a/localization/da/strings.po
+++ b/localization/da/strings.po
@@ -2598,7 +2598,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr "mængdeenhed konverteringsproblem løst"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Vare specifikke mængdeenhed omregning"
 
 msgid "Default quantity unit consume"

--- a/localization/de/strings.po
+++ b/localization/de/strings.po
@@ -2697,7 +2697,7 @@ msgstr "Aufgelöste ME-Umrechnungen anzeigen"
 msgid "QU conversions resolved"
 msgstr "Aufgelöste ME-Umrechnungen"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Produktspezifische ME-Umrechnungen"
 
 msgid "Default quantity unit consume"

--- a/localization/el_GR/strings.po
+++ b/localization/el_GR/strings.po
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/en_GB/strings.po
+++ b/localization/en_GB/strings.po
@@ -2648,8 +2648,8 @@ msgstr "Show resolved conversions"
 msgid "QU conversions resolved"
 msgstr "QU conversions resolved"
 
-msgid "Product specifc QU conversions"
-msgstr "Product specifc QU conversions"
+msgid "Product specific QU conversions"
+msgstr "Product specific QU conversions"
 
 msgid "Default quantity unit consume"
 msgstr "Default quantity unit consume"

--- a/localization/es/strings.po
+++ b/localization/es/strings.po
@@ -2753,7 +2753,7 @@ msgstr "Mostrar conversiones resueltas"
 msgid "QU conversions resolved"
 msgstr "QU conversiones resueltas "
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "QU conversiones de producto específico "
 
 msgid "Default quantity unit consume"

--- a/localization/et_EE/strings.po
+++ b/localization/et_EE/strings.po
@@ -2652,7 +2652,7 @@ msgstr "Näita lahendatud teisendusi"
 msgid "QU conversions resolved"
 msgstr "Koguseühiku teisendusi lahendatud"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Tootele omased koguseühikute teisendused"
 
 msgid "Default quantity unit consume"

--- a/localization/fi/strings.po
+++ b/localization/fi/strings.po
@@ -2599,7 +2599,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/fr/strings.po
+++ b/localization/fr/strings.po
@@ -2758,7 +2758,7 @@ msgstr "Afficher les conversions résolues"
 msgid "QU conversions resolved"
 msgstr "Conversions d'UQ résolue"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Conversions UQ spécifiques au produit"
 
 msgid "Default quantity unit consume"

--- a/localization/he_IL/strings.po
+++ b/localization/he_IL/strings.po
@@ -2676,7 +2676,7 @@ msgstr "הצגת דיונים שנפתרו"
 msgid "QU conversions resolved"
 msgstr "המרות יחידות כמות נפתרו"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "המרות יחידות כמות נקודתיות למוצר"
 
 msgid "Default quantity unit consume"

--- a/localization/hu/strings.po
+++ b/localization/hu/strings.po
@@ -2671,7 +2671,7 @@ msgstr "Mutassa a felismert átváltásokat"
 msgid "QU conversions resolved"
 msgstr "Felismert ME átváltások"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Termék specifikus mennyiségi egység váltások"
 
 msgid "Default quantity unit consume"

--- a/localization/it/strings.po
+++ b/localization/it/strings.po
@@ -2761,7 +2761,7 @@ msgstr "Mostra le conversioni risolte"
 msgid "QU conversions resolved"
 msgstr "UQ di conversioni risolte"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "UQ di conversioni specifiche per il prodotto"
 
 msgid "Default quantity unit consume"

--- a/localization/ja/strings.po
+++ b/localization/ja/strings.po
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/ko_KR/strings.po
+++ b/localization/ko_KR/strings.po
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/lt/strings.po
+++ b/localization/lt/strings.po
@@ -2732,7 +2732,7 @@ msgstr "Rodyti užbaigtas konversijas"
 msgid "QU conversions resolved"
 msgstr "QU konversijos išspręstos"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Konkretaus produkto QU konversijos"
 
 msgid "Default quantity unit consume"

--- a/localization/nl/strings.po
+++ b/localization/nl/strings.po
@@ -2724,7 +2724,7 @@ msgstr "Toon opgeloste conversies"
 msgid "QU conversions resolved"
 msgstr "Hoeveelheidseenheid conversies opgelost"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Product-specifieke hoeveelheidseenheid conversies"
 
 msgid "Default quantity unit consume"

--- a/localization/no/strings.po
+++ b/localization/no/strings.po
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/pl/strings.po
+++ b/localization/pl/strings.po
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/pt_BR/strings.po
+++ b/localization/pt_BR/strings.po
@@ -2732,7 +2732,7 @@ msgstr "Mostrar conversões resolvidas"
 msgid "QU conversions resolved"
 msgstr "QU conversões resolvidas"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Conversões de unidade específicas"
 
 msgid "Default quantity unit consume"

--- a/localization/pt_PT/strings.po
+++ b/localization/pt_PT/strings.po
@@ -2599,7 +2599,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/ro_RO/strings.po
+++ b/localization/ro_RO/strings.po
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/ru/strings.po
+++ b/localization/ru/strings.po
@@ -2704,7 +2704,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/sk_SK/strings.po
+++ b/localization/sk_SK/strings.po
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/sl/strings.po
+++ b/localization/sl/strings.po
@@ -2581,7 +2581,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/sv_SE/strings.po
+++ b/localization/sv_SE/strings.po
@@ -2578,7 +2578,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/ta/strings.po
+++ b/localization/ta/strings.po
@@ -2500,7 +2500,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/tr/strings.po
+++ b/localization/tr/strings.po
@@ -2657,7 +2657,7 @@ msgstr "Çözümlenen dönüşümleri göster"
 msgid "QU conversions resolved"
 msgstr "QU dönüşümleri çözüldü"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "Ürüne özel QU dönüşümleri"
 
 msgid "Default quantity unit consume"

--- a/localization/uk/strings.po
+++ b/localization/uk/strings.po
@@ -2669,7 +2669,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/localization/zh_CN/strings.po
+++ b/localization/zh_CN/strings.po
@@ -2472,7 +2472,7 @@ msgstr "显示转换过的单位"
 msgid "QU conversions resolved"
 msgstr "单位转换已完成"
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr "产品特有的数量单位转换"
 
 msgid "Default quantity unit consume"

--- a/localization/zh_TW/strings.po
+++ b/localization/zh_TW/strings.po
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "QU conversions resolved"
 msgstr ""
 
-msgid "Product specifc QU conversions"
+msgid "Product specific QU conversions"
 msgstr ""
 
 msgid "Default quantity unit consume"

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -761,7 +761,7 @@
 			<div class="col">
 				<div class="title-related-links">
 					<h4>
-						{{ $__t('Product specifc QU conversions') }}
+						{{ $__t('Product specific QU conversions') }}
 					</h4>
 					<button class="btn btn-outline-dark d-md-none mt-2 float-right order-1 order-md-3"
 						type="button"


### PR DESCRIPTION
I've just installed Grocy—looking forward to inventory my kitchen and start using it! 😄 

While browsing the UI, I noticed a typo in the "Edit product" page; here's a PR to fix it. I did a simple search and replace, so let me know if I missed anything.