### PR TITLE
Added 'category' filter to tasks view.

### DIFF
--- a/public/viewjs/tasks.js
+++ b/public/viewjs/tasks.js
@@ -41,6 +41,7 @@ $("#category-filter").on("change", function()
 	{
 		value = "";
 	}
+
 	tasksTable.column(tasksTable.colReorder.transpose(6)).search(value).draw();
 });
 

--- a/public/viewjs/tasks.js
+++ b/public/viewjs/tasks.js
@@ -42,7 +42,7 @@ $("#category-filter").on("change", function()
 		value = "";
 	}
 
-	tasksTable.column(tasksTable.colReorder.transpose(6)).search(value).draw();
+	tasksTable.column(tasksTable.colReorder.transpose(3)).search(value).draw();
 });
 
 $("#clear-filter-button").on("click", function()

--- a/public/viewjs/tasks.js
+++ b/public/viewjs/tasks.js
@@ -41,10 +41,6 @@ $("#category-filter").on("change", function()
 	{
 		value = "";
 	}
-
-	// Transfer CSS classes of selected element to dropdown element (for background)
-	$(this).attr("class", $("#" + $(this).attr("id") + " option[value='" + value + "']").attr("class") + " form-control");
-
 	tasksTable.column(tasksTable.colReorder.transpose(6)).search(value).draw();
 });
 

--- a/public/viewjs/tasks.js
+++ b/public/viewjs/tasks.js
@@ -34,12 +34,28 @@ $("#status-filter").on("change", function()
 	tasksTable.column(tasksTable.colReorder.transpose(5)).search(value).draw();
 });
 
+$("#category-filter").on("change", function()
+{
+	var value = $(this).val();
+	if (value === "all")
+	{
+		value = "";
+	}
+
+	// Transfer CSS classes of selected element to dropdown element (for background)
+	$(this).attr("class", $("#" + $(this).attr("id") + " option[value='" + value + "']").attr("class") + " form-control");
+
+	tasksTable.column(tasksTable.colReorder.transpose(6)).search(value).draw();
+});
+
 $("#clear-filter-button").on("click", function()
 {
 	$("#search").val("");
 	$("#status-filter").val("all");
+	$("#category-filter").val("all");
 	$("#search").trigger("keyup");
 	$("#status-filter").trigger("change");
+	$("#category-filter").trigger("change");
 	$("#show-done-tasks").trigger('checked', false);
 });
 

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -81,7 +81,7 @@
 			</select>
 		</div>
 	</div>
-<div class="col-12 col-md-6 col-xl-3">
+	<div class="col-12 col-md-6 col-xl-3">
 		<div class="input-group">
 			<div class="input-group-prepend">
 				<span class="input-group-text"><i class="fa-solid fa-filter"></i>&nbsp;{{ $__t('Category') }}</span>
@@ -90,7 +90,7 @@
 				id="category-filter">
 				<option value="all">{{ $__t('All') }}</option>
 				@foreach($taskCategories as $taskCategory)
-					<option value="{{ $taskCategory->name }}">{{ $__t($taskCategory->name) }}</option>
+				<option value="{{ $taskCategory->name }}">{{ $__t($taskCategory->name) }}</option>
 				@endforeach
 			</select>
 		</div>

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -92,6 +92,8 @@
 				@foreach($taskCategories as $taskCategory)
 				<option value="{{ $taskCategory->name }}">{{ $taskCategory->name }}</option>
 				@endforeach
+				<option class="font-italic font-weight-light"
+					value="{{ $__t('Uncategorized') }}">{{ $__t('Uncategorized') }}</option>
 			</select>
 		</div>
 	</div>

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -81,6 +81,20 @@
 			</select>
 		</div>
 	</div>
+<div class="col-12 col-md-6 col-xl-3">
+		<div class="input-group">
+			<div class="input-group-prepend">
+				<span class="input-group-text"><i class="fa-solid fa-filter"></i>&nbsp;{{ $__t('Category') }}</span>
+			</div>
+			<select class="custom-control custom-select"
+				id="category-filter">
+				<option value="all">{{ $__t('All') }}</option>
+				@foreach($taskCategories as $taskCategory)
+					<option value="{{ $taskCategory->name }}">{{ $__t($taskCategory->name) }}</option>
+				@endforeach
+			</select>
+		</div>
+	</div>
 	<div class="col-12 col-md-6 col-xl-3">
 		<div class="form-check custom-control custom-checkbox">
 			<input class="form-check-input custom-control-input"

--- a/views/tasks.blade.php
+++ b/views/tasks.blade.php
@@ -90,7 +90,7 @@
 				id="category-filter">
 				<option value="all">{{ $__t('All') }}</option>
 				@foreach($taskCategories as $taskCategory)
-				<option value="{{ $taskCategory->name }}">{{ $__t($taskCategory->name) }}</option>
+				<option value="{{ $taskCategory->name }}">{{ $taskCategory->name }}</option>
 				@endforeach
 			</select>
 		</div>


### PR DESCRIPTION
The 'Tasks' view had an empty space for another default filter along the header bar. I have a lot of categories and it simplifies presentation to filter according to the task category without adding a lot of unnecessary clutter to the view.

<img width="1101" alt="image" src="https://github.com/grocy/grocy/assets/9195984/edab764b-2869-4b92-bd5b-4bcd22bd47c4">

I would be happy to add this as a configurable option but I wanted to check first whether we could just include it by default. Happy to take feedback or suggestions.