### PR TITLE
Change Openapi descriptions for easier use of auto-generated api client

### DIFF
--- a/controllers/OpenApiController.php
+++ b/controllers/OpenApiController.php
@@ -127,11 +127,11 @@ class OpenApiController extends BaseApiController
 			"stock_log" => "StockLogEntry",
 			"stock" => "StockEntry",
 			///			"stock_current_locations" => ,
-			"chores_log" => "ChoreLogEntry"
+			"chores_log" => "ChoreLogEntry",
 			//"meal_plan_sections",
 			//"products_last_purchased",
 			//"products_average_price",
-			//"quantity_unit_conversions_resolved",
+			"quantity_unit_conversions_resolved" => "QuantityUnitConversionResolved",
 			//"recipes_pos_resolved"
 		);
 		// non-generic entity api

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -4733,7 +4733,10 @@
 						"$ref": "#/components/schemas/Product"
 					},
 					"product_barcodes": {
-						"$ref": "#/components/schemas/ProductBarcode"
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/ProductBarcode"
+						}
 					},
 					"quantity_unit_stock": {
 						"$ref": "#/components/schemas/QuantityUnit"

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5282,7 +5282,7 @@
 					},
 					"purchased_date": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"used_date": {
 						"type": "string",

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -401,15 +401,6 @@
 				"parameters": [
 					{
 						"in": "path",
-						"name": "entity",
-						"required": true,
-						"description": "A valid entity name",
-						"schema": {
-							"$ref": "#/components/schemas/ExposedEntity_NotIncludingNotListable"
-						}
-					},
-					{
-						"in": "path",
 						"name": "objectId",
 						"required": true,
 						"description": "A valid object id of the given entity",
@@ -485,15 +476,6 @@
 				"parameters": [
 					{
 						"in": "path",
-						"name": "entity",
-						"required": true,
-						"description": "A valid entity name",
-						"schema": {
-							"$ref": "#/components/schemas/ExposedEntity_NotIncludingNotEditable"
-						}
-					},
-					{
-						"in": "path",
 						"name": "objectId",
 						"required": true,
 						"description": "A valid object id of the given entity",
@@ -560,15 +542,6 @@
 					"Generic entity interactions"
 				],
 				"parameters": [
-					{
-						"in": "path",
-						"name": "entity",
-						"required": true,
-						"description": "A valid entity name",
-						"schema": {
-							"$ref": "#/components/schemas/ExposedEntity_NotIncludingNotDeletable"
-						}
-					},
 					{
 						"in": "path",
 						"name": "objectId",

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5724,6 +5724,41 @@
 					}
 				}
 			},
+			"QuantityUnitConversionResolved": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer"
+					},
+					"product_id": {
+						"type": "integer"
+					},
+					"from_qu_id": {
+						"type": "integer"
+					},
+					"from_qu_name": {
+						"type": "string"
+					},
+					"from_qu_name_plural": {
+						"type": "string"
+					},
+					"to_qu_id": {
+						"type": "integer"
+					},
+					"to_qu_name": {
+						"type": "string"
+					},
+					"to_qu_name_plural": {
+						"type": "string"
+					},
+					"factor": {
+						"type": "number"
+					},
+					"path": {
+						"type": "string"
+					}
+				}
+			},
 			"ExposedEntity": {
 				"type": "string",
 				"enum": [

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5289,8 +5289,8 @@
 						"format": "date"
 					},
 					"spoiled": {
-						"type": "boolean",
-						"default": false
+						"type": "integer",
+						"default": 0
 					},
 					"stock_id": {
 						"type": "string"

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5866,7 +5866,6 @@
 			"StringEnumTemplate": {
 				"type": "string",
 				"enum": [
-					""
 				]
 			}
 		},

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -4753,7 +4753,7 @@
 					},
 					"last_used": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"stock_amount": {
 						"type": "number"
@@ -4763,7 +4763,7 @@
 					},
 					"next_due_date": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"last_price": {
 						"type": "number",

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -248,15 +248,6 @@
 				],
 				"parameters": [
 					{
-						"in": "path",
-						"name": "entity",
-						"required": true,
-						"description": "A valid entity name",
-						"schema": {
-							"$ref": "#/components/schemas/ExposedEntity_NotIncludingNotListable"
-						}
-					},
-					{
 						"$ref": "#/components/parameters/query"
 					},
 					{
@@ -334,17 +325,6 @@
 				"summary": "Adds a single object of the given entity",
 				"tags": [
 					"Generic entity interactions"
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "entity",
-						"required": true,
-						"description": "A valid entity name",
-						"schema": {
-							"$ref": "#/components/schemas/ExposedEntity_NotIncludingNotEditable"
-						}
-					}
 				],
 				"requestBody": {
 					"description": "A valid entity object of the entity specified in parameter *entity*",


### PR DESCRIPTION
Hi!

Thanks for making this awesome household management tool!

I am currently writing some helper programs which interact with grocy api. I am doing this in Java and generating the client api bindings with swagger.  During that I ran into some problems regarding the fact that openapi description does not exactly match the actual api. 

- in some types it is stated that field type is `date-time` even if the field contains only a `date` -- this PR changes format form `date-time` do `date`,
- the `ProductDetailsResponse` type contains `product_barcodes` field. Openapi says that it contains a `ProductBarcode` item while actual type is an array of such items.
- the `spoiled` field in stock entry in api description is declaread as a boolean. Sematically it is a boolean but the values returned are 0 or 1, so it cannot be parsed as a boolean.

Besides that I found using the generated bindings for the generic entity api rather hard to use. Every time I fetch some data, for instance a product or quantity unit, etc. I need to check the type of a returned object and cast it into the requested entity type (this is because java is a statically typed language). A part of this PR (commits 641be7ee30d4f9d8547e231de39367e5fd2442a0 and 6599da09e7c37c827651c3be94a9f6df8b485c6c) changes the description of the generic entity api from a single `/objects/{entity}` endpoint that has an entity type parameter to many endpoints where there is separate api endpoint for `/object/XXX` for each object.  This way each of new endpoints has a single possible return type, so no casting is needed.

This PR changes **only openapi description**. No changes to actual API are made so it should not break any existing programs using the API. (In the PR I tried to avoid API breaks at all cost even if IMO it is better to change some things in API responses).

The changes in commits 641be7ee30d4f9d8547e231de39367e5fd2442a0 and 6599da09e7c37c827651c3be94a9f6df8b485c6c will change the auto-generated bindings for anyone who uses such and therefore it may break things. If this is a problem I can submit another PR excluding those two commits.

This PR does not solve all the problems I had with auto-generated bindings. I had one more: `row_created_timestamp` is not formatted in accordance to JSON schema for `date-time` as the JSON Schema spec requires that `date-time` contains a timezone. Currently I've done a workaround on a client side as changing it in grocy may break the programs that already use the API.