### PR TITLE
Fix data types in opeanapi description

### DIFF
--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -4733,7 +4733,10 @@
 						"$ref": "#/components/schemas/Product"
 					},
 					"product_barcodes": {
-						"$ref": "#/components/schemas/ProductBarcode"
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/ProductBarcode"
+						}
 					},
 					"quantity_unit_stock": {
 						"$ref": "#/components/schemas/QuantityUnit"

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -4753,7 +4753,7 @@
 					},
 					"last_used": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"stock_amount": {
 						"type": "number"
@@ -4763,7 +4763,7 @@
 					},
 					"next_due_date": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"last_price": {
 						"type": "number",

--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -5329,7 +5329,7 @@
 					},
 					"purchased_date": {
 						"type": "string",
-						"format": "date-time"
+						"format": "date"
 					},
 					"used_date": {
 						"type": "string",


### PR DESCRIPTION
A subset of changes proposed in #2429

- the `ProductDetailsResponse` type contains product_barcodes field. Openapi says that it contains a `ProductBarcode` item while actual type is an array of such items.
- change several occurences of `date-time` to `date` in cases where only date is returned