### PR TITLE
Stream uploads to file

### DIFF
--- a/controllers/FilesApiController.php
+++ b/controllers/FilesApiController.php
@@ -109,9 +109,26 @@ class FilesApiController extends BaseApiController
 			}
 
 			$fileName = $this->checkFileName($args['fileName']);
-			$data = $request->getBody()->getContents();
 
-			file_put_contents($this->getFilesService()->GetFilePath($args['group'], $fileName), $data);
+			if(false === $fileHandle = fopen($this->getFilesService()->GetFilePath($args['group'], $fileName), 'xb'))
+			{
+				throw new \Exception('Cannot create file');
+			}
+
+			$requestBody = $request->getBody();
+
+			while ($data = $requestBody->read(32768))
+			{
+				if ( fwrite($fileHandle, $data) === false )
+				{
+					throw new \Exception('Cannot write to file');
+				}
+			}
+
+			if ( fclose($fileHandle) === false )
+			{
+				throw new \Exception('Failed to close file');
+			}
 
 			return $this->EmptyApiResponse($response);
 		}

--- a/controllers/FilesApiController.php
+++ b/controllers/FilesApiController.php
@@ -110,24 +110,25 @@ class FilesApiController extends BaseApiController
 
 			$fileName = $this->checkFileName($args['fileName']);
 
-			if(false === $fileHandle = fopen($this->getFilesService()->GetFilePath($args['group'], $fileName), 'xb'))
+			$fileHandle = fopen($this->getFilesService()->GetFilePath($args['group'], $fileName), 'xb');
+			if($fileHandle === false)
 			{
-				throw new \Exception('Cannot create file');
+				throw new \Exception("Error while creating file $fileName");
 			}
 
+			// Save the file to disk in chunks of 1 MB
 			$requestBody = $request->getBody();
-
-			while ($data = $requestBody->read(32768))
+			while ($data = $requestBody->read(1048576))
 			{
-				if ( fwrite($fileHandle, $data) === false )
+				if (fwrite($fileHandle, $data) === false)
 				{
-					throw new \Exception('Cannot write to file');
+					throw new \Exception("Error while writing file $fileName");
 				}
 			}
 
-			if ( fclose($fileHandle) === false )
+			if (fclose($fileHandle) === false)
 			{
-				throw new \Exception('Failed to close file');
+				throw new \Exception("Error while closing file $fileName");
 			}
 
 			return $this->EmptyApiResponse($response);


### PR DESCRIPTION
Currently, file uploads are buffered in memory. For very large uploads this can cause a memory exhaustion and I noticed the following error:

```text
NOTICE: PHP message: PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 98566176 bytes) in /var/www/grocy/packages/slim/psr7/src/Stream.php on line 357
```

This pull request changes the logic to stream an upload directly into the target file (using a chunk size of 32 KB). Now the maximum file size is only controlled by the likes of `client_max_body_size` and no longer affected by the PHP `memory_limit`.

Please just let me know if anything shall be revised, or you would like to receive the pull request in a different format.