### PR TITLE
Added alternative quick actions

### DIFF
--- a/localization/de/strings.po
+++ b/localization/de/strings.po
@@ -2802,3 +2802,6 @@ msgstr "Für den angegebenen Barcode wurde nichts gefunden"
 
 msgid "Configure colors"
 msgstr "Farben konfigurieren"
+
+msgid "Use alternative quick actions"
+msgstr "Alternative Schnellaktionen benutzen"

--- a/localization/en/strings.po
+++ b/localization/en/strings.po
@@ -1205,3 +1205,6 @@ msgstr "This is required and can only contain letters and numbers"
 
 msgid "Edit userfield"
 msgstr "Edit userfield"
+
+msgid "Use alternative quick actions"
+msgstr "Use alternative quick actions"

--- a/public/viewjs/stocksettings.js
+++ b/public/viewjs/stocksettings.js
@@ -51,3 +51,8 @@ $("#stock_default_consume_amount_use_quick_consume_amount").on("click", function
 		$("#stock_default_consume_amount").removeAttr("disabled");
 	}
 });
+
+if (BoolVal(Grocy.UserSettings.use_alternative_actions_on_stock_overview_page))
+{
+	$("#use_alternative_actions_on_stock_overview_page").prop("checked", true);
+}

--- a/views/components/quickactions.blade.php
+++ b/views/components/quickactions.blade.php
@@ -1,0 +1,50 @@
+@if(boolval($userSettings['use_alternative_actions_on_stock_overview_page']))
+<a id="product-{{ $currentStockEntry->product_id }}-consume-button"
+	class="permission-STOCK_CONSUME btn btn-success btn-sm product-consume-button show-as-dialog-link @if($currentStockEntry->amount_aggregated == 0) disabled @endif"
+	href="{{ $U('/consume?embedded&product=' . $currentStockEntry->product_id ) }}">
+	<i class="fa-solid fa-utensils"></i> {{ $__t('Consume') }}
+</a>
+<a id="product-{{ $currentStockEntry->product_id }}-consume-button"
+	class="permission-STOCK_TRANSFER btn btn-info btn-sm show-as-dialog-link @if($currentStockEntry->amount <= 0) disabled @endif"
+	href="{{ $U('/transfer?embedded&product=' . $currentStockEntry->product_id ) }}">
+	<i class="fa-solid fa-exchange-alt"></i>
+</a>
+@else
+<a class="permission-STOCK_CONSUME btn btn-success btn-sm product-consume-button @if($currentStockEntry->amount_aggregated < $currentStockEntry->quick_consume_amount || $currentStockEntry->enable_tare_weight_handling == 1) disabled @endif"
+	href="#"
+	data-toggle="tooltip"
+	data-placement="left"
+	title="{{ $__t('Consume %1$s of %2$s', $currentStockEntry->quick_consume_amount_qu_consume . ' ' . $currentStockEntry->qu_consume_name, $currentStockEntry->product_name) }}"
+	data-product-id="{{ $currentStockEntry->product_id }}"
+	data-product-name="{{ $currentStockEntry->product_name }}"
+	data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
+	data-consume-amount="{{ $currentStockEntry->quick_consume_amount }}">
+	<i class="fa-solid fa-utensils"></i> <span class="locale-number locale-number-quantity-amount">{{ $currentStockEntry->quick_consume_amount_qu_consume }}</span>
+</a>
+<a id="product-{{ $currentStockEntry->product_id }}-consume-all-button"
+	class="permission-STOCK_CONSUME btn btn-danger btn-sm product-consume-button @if($currentStockEntry->amount_aggregated == 0) disabled @endif"
+	href="#"
+	data-toggle="tooltip"
+	data-placement="right"
+	title="{{ $__t('Consume all %s which are currently in stock', $currentStockEntry->product_name) }}"
+	data-product-id="{{ $currentStockEntry->product_id }}"
+	data-product-name="{{ $currentStockEntry->product_name }}"
+	data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
+	data-consume-amount="@if($currentStockEntry->enable_tare_weight_handling == 1){{$currentStockEntry->tare_weight}}@else{{$currentStockEntry->amount}}@endif"
+	data-original-total-stock-amount="{{$currentStockEntry->amount}}">
+	<i class="fa-solid fa-utensils"></i> {{ $__t('All') }}
+</a>
+@if(GROCY_FEATURE_FLAG_STOCK_PRODUCT_OPENED_TRACKING)
+<a class="btn btn-success btn-sm product-open-button @if($currentStockEntry->amount_aggregated < $currentStockEntry->quick_open_amount || $currentStockEntry->amount_aggregated == $currentStockEntry->amount_opened_aggregated || $currentStockEntry->enable_tare_weight_handling == 1) disabled @endif"
+	href="#"
+	data-toggle="tooltip"
+	data-placement="left"
+	title="{{ $__t('Mark %1$s of %2$s as open', $currentStockEntry->quick_open_amount_qu_consume . ' ' . $currentStockEntry->qu_consume_name, $currentStockEntry->product_name) }}"
+	data-product-id="{{ $currentStockEntry->product_id }}"
+	data-product-name="{{ $currentStockEntry->product_name }}"
+	data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
+	data-open-amount="{{ $currentStockEntry->quick_open_amount }}">
+	<i class="fa-solid fa-box-open"></i> <span class="locale-number locale-number-quantity-amount">{{ $currentStockEntry->quick_open_amount_qu_consume }}</span>
+</a>
+@endif
+@endif

--- a/views/stockoverview.blade.php
+++ b/views/stockoverview.blade.php
@@ -196,43 +196,7 @@
 				<tr id="product-{{ $currentStockEntry->product_id }}-row"
 					class="@if(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime('-1 days')) && $currentStockEntry->amount > 0) @if($currentStockEntry->due_type == 1) table-secondary @else table-danger @endif @elseif(GROCY_FEATURE_FLAG_STOCK_BEST_BEFORE_DATE_TRACKING && $currentStockEntry->best_before_date < date('Y-m-d 23:59:59', strtotime('+' . $nextXDays . ' days')) && $currentStockEntry->amount > 0) table-warning @elseif ($currentStockEntry->product_missing) table-info @endif">
 					<td class="fit-content border-right">
-						<a class="permission-STOCK_CONSUME btn btn-success btn-sm product-consume-button @if($currentStockEntry->amount_aggregated < $currentStockEntry->quick_consume_amount || $currentStockEntry->enable_tare_weight_handling == 1) disabled @endif"
-							href="#"
-							data-toggle="tooltip"
-							data-placement="left"
-							title="{{ $__t('Consume %1$s of %2$s', $currentStockEntry->quick_consume_amount_qu_consume . ' ' . $currentStockEntry->qu_consume_name, $currentStockEntry->product_name) }}"
-							data-product-id="{{ $currentStockEntry->product_id }}"
-							data-product-name="{{ $currentStockEntry->product_name }}"
-							data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
-							data-consume-amount="{{ $currentStockEntry->quick_consume_amount }}">
-							<i class="fa-solid fa-utensils"></i> <span class="locale-number locale-number-quantity-amount">{{ $currentStockEntry->quick_consume_amount_qu_consume }}</span>
-						</a>
-						<a id="product-{{ $currentStockEntry->product_id }}-consume-all-button"
-							class="permission-STOCK_CONSUME btn btn-danger btn-sm product-consume-button @if($currentStockEntry->amount_aggregated == 0) disabled @endif"
-							href="#"
-							data-toggle="tooltip"
-							data-placement="right"
-							title="{{ $__t('Consume all %s which are currently in stock', $currentStockEntry->product_name) }}"
-							data-product-id="{{ $currentStockEntry->product_id }}"
-							data-product-name="{{ $currentStockEntry->product_name }}"
-							data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
-							data-consume-amount="@if($currentStockEntry->enable_tare_weight_handling == 1){{$currentStockEntry->tare_weight}}@else{{$currentStockEntry->amount}}@endif"
-							data-original-total-stock-amount="{{$currentStockEntry->amount}}">
-							<i class="fa-solid fa-utensils"></i> {{ $__t('All') }}
-						</a>
-						@if(GROCY_FEATURE_FLAG_STOCK_PRODUCT_OPENED_TRACKING)
-						<a class="btn btn-success btn-sm product-open-button @if($currentStockEntry->amount_aggregated < $currentStockEntry->quick_open_amount || $currentStockEntry->amount_aggregated == $currentStockEntry->amount_opened_aggregated || $currentStockEntry->enable_tare_weight_handling == 1) disabled @endif"
-							href="#"
-							data-toggle="tooltip"
-							data-placement="left"
-							title="{{ $__t('Mark %1$s of %2$s as open', $currentStockEntry->quick_open_amount_qu_consume . ' ' . $currentStockEntry->qu_consume_name, $currentStockEntry->product_name) }}"
-							data-product-id="{{ $currentStockEntry->product_id }}"
-							data-product-name="{{ $currentStockEntry->product_name }}"
-							data-product-qu-name="{{ $currentStockEntry->qu_stock_name }}"
-							data-open-amount="{{ $currentStockEntry->quick_open_amount }}">
-							<i class="fa-solid fa-box-open"></i> <span class="locale-number locale-number-quantity-amount">{{ $currentStockEntry->quick_open_amount_qu_consume }}</span>
-						</a>
-						@endif
+						@include('components.quickactions')
 						<div class="dropdown d-inline-block">
 							<button class="btn btn-sm btn-light text-secondary"
 								type="button"

--- a/views/stocksettings.blade.php
+++ b/views/stocksettings.blade.php
@@ -207,6 +207,19 @@
 
 		@endif
 
+		<div class="form-group">
+			<div class="custom-control custom-checkbox">
+				<input type="checkbox"
+					class="form-check-input custom-control-input user-setting-control"
+					id="use_alternative_actions_on_stock_overview_page"
+					data-setting-key="use_alternative_actions_on_stock_overview_page">
+				<label class="form-check-label custom-control-label"
+					for="use_alternative_actions_on_stock_overview_page">
+					{{ $__t('Use alternative quick actions') }}
+				</label>
+			</div>
+		</div>
+
 		<a href="{{ $U('/stockoverview') }}"
 			class="btn btn-success">{{ $__t('OK') }}</a>
 	</div>


### PR DESCRIPTION
## What?
![image that shows the stockoverview page with the alternative design enabled](https://github.com/grocy/grocy/assets/62173745/31f31c2a-c721-49c7-9149-a12b63d298a8)

- Enable 'Use alternative quick actions' under `/stocksettings`
- The 3 default Quick Actions will be replaced by two Quick actions that each open a dialog (The Consume-dialog and the transfer dialog)

## How?
- Added a "Quick Action Component" `views/components/quickactions.blade.php` that handles the buttons in the first table column (excluding the dropdown)
- New UserSetting svalue `use_alternative_actions_on_stock_overview_page` that controls if the alternative design is enabled.

## Why?
It bothered me, that I always had to go through the dropdown menu to get access to the "advanced" settings for consuming, so I added this feature to enable this view.