### PR TITLE
fix(consume): convert bounds to selected quantity unit

### DIFF
--- a/changelog/76_UNRELEASED_xxxx-xx-xx.md
+++ b/changelog/76_UNRELEASED_xxxx-xx-xx.md
@@ -15,6 +15,7 @@
   - If the lookup was successful, the product edit page of the created product is displayed, where the product setup can be completed (if required)
   - After that, the transaction is continued with that product
 - Fixed that when copying a product, the field "Treat opened as out of stock" wasn't copied along (thanks @TheDodger)
+- Fixed conversion of minimum/maximum product amount to selected quantity unit in consume view
 
 ### Shopping list
 

--- a/public/viewjs/consume.js
+++ b/public/viewjs/consume.js
@@ -102,7 +102,7 @@
 						Grocy.Components.ProductPicker.FinishFlow();
 
 						Grocy.Components.ProductAmountPicker.Reset();
-						$("#display_amount").attr("min", Grocy.DefaultMinAmount);
+						$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
 						$("#display_amount").removeAttr("max");
 						if (BoolVal(Grocy.UserSettings.stock_default_consume_amount_use_quick_consume_amount))
 						{
@@ -249,7 +249,7 @@ $("#location_id").on('change', function(e)
 					function(stockEntries)
 					{
 						OnLocationChange(stockEntries[0].location_id, gc[3]);
-						$('#display_amount').val(stockEntries[0].amount);
+						$("#display_amount").val(stockEntries[0].amount * $("#qu_id option:selected").attr("data-qu-factor"));
 					},
 					function(xhr)
 					{
@@ -476,13 +476,13 @@ Grocy.Components.ProductPicker.GetPicker().on('change', function(e)
 
 				if (productDetails.product.enable_tare_weight_handling == 1)
 				{
-					$("#display_amount").attr("min", productDetails.product.tare_weight);
-					$('#display_amount').attr('max', productDetails.stock_amount + productDetails.product.tare_weight);
+					$("#display_amount").attr("min", productDetails.product.tare_weight * $("#qu_id option:selected").attr("data-qu-factor"));
+					$("#display_amount").attr("max", (productDetails.stock_amount + productDetails.product.tare_weight) * $("#qu_id option:selected").attr("data-qu-factor"));
 					$("#tare-weight-handling-info").removeClass("d-none");
 				}
 				else
 				{
-					$("#display_amount").attr("min", Grocy.DefaultMinAmount);
+					$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
 					$("#tare-weight-handling-info").addClass("d-none");
 				}
 
@@ -564,7 +564,7 @@ $("#specific_stock_entry").on("change", function(e)
 						sumValue = sumValue + stockEntry.amount_aggregated;
 					}
 				});
-				$("#display_amount").attr("max", sumValue);
+				$("#display_amount").attr("max", sumValue * $("#qu_id option:selected").attr("data-qu-factor"));
 				if (sumValue == 0)
 				{
 					$("#display_amount").parent().find(".invalid-feedback").text(__t('There are no units available at this location'));
@@ -578,7 +578,7 @@ $("#specific_stock_entry").on("change", function(e)
 	}
 	else
 	{
-		$("#display_amount").attr("max", $('option:selected', this).attr('amount'));
+		$("#display_amount").attr("max", $("option:selected", this).attr("amount") * $("#qu_id option:selected").attr("data-qu-factor"));
 	}
 });
 
@@ -700,16 +700,16 @@ function RefreshForm()
 
 	if (productDetails.product.enable_tare_weight_handling == 1 && !$('#consume-exact-amount').is(':checked'))
 	{
-		$("#display_amount").attr("min", productDetails.product.tare_weight);
-		$('#display_amount').attr('max', sumValue + productDetails.product.tare_weight);
+		$("#display_amount").attr("min", productDetails.product.tare_weight * $("#qu_id option:selected").attr("data-qu-factor"));
+		$("#display_amount").attr("max", (sumValue + productDetails.product.tare_weight) * $("#qu_id option:selected").attr("data-qu-factor"));
 		$("#tare-weight-handling-info").removeClass("d-none");
 	}
 	else
 	{
 		$("#tare-weight-handling-info").addClass("d-none");
 
-		$("#display_amount").attr("min", Grocy.DefaultMinAmount);
-		$('#display_amount').attr('max', sumValue * $("#qu_id option:selected").attr("data-qu-factor"));
+		$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
+		$("#display_amount").attr("max", sumValue * $("#qu_id option:selected").attr("data-qu-factor"));
 
 		if (sumValue == 0)
 		{

--- a/public/viewjs/consume.js
+++ b/public/viewjs/consume.js
@@ -1,4 +1,4 @@
-﻿$('#save-consume-button').on('click', function(e)
+$('#save-consume-button').on('click', function(e)
 {
 	e.preventDefault();
 
@@ -102,7 +102,7 @@
 						Grocy.Components.ProductPicker.FinishFlow();
 
 						Grocy.Components.ProductAmountPicker.Reset();
-						$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
+						$("#display_amount").attr("min", Grocy.DefaultMinAmount);
 						$("#display_amount").removeAttr("max");
 						if (BoolVal(Grocy.UserSettings.stock_default_consume_amount_use_quick_consume_amount))
 						{
@@ -482,7 +482,7 @@ Grocy.Components.ProductPicker.GetPicker().on('change', function(e)
 				}
 				else
 				{
-					$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
+					$("#display_amount").attr("min", Grocy.DefaultMinAmount);
 					$("#tare-weight-handling-info").addClass("d-none");
 				}
 
@@ -708,8 +708,8 @@ function RefreshForm()
 	{
 		$("#tare-weight-handling-info").addClass("d-none");
 
-		$("#display_amount").attr("min", Grocy.DefaultMinAmount * $("#qu_id option:selected").attr("data-qu-factor"));
-		$("#display_amount").attr("max", sumValue * $("#qu_id option:selected").attr("data-qu-factor"));
+		$("#display_amount").attr("min", Grocy.DefaultMinAmount);
+		$('#display_amount').attr('max', sumValue * $("#qu_id option:selected").attr("data-qu-factor"));
 
 		if (sumValue == 0)
 		{


### PR DESCRIPTION
The minimum/maximum value of the amount field for products with tare weight handling is broken on the `/consume` page. The bounds should be multiplied by the conversion factor of the selected quantity unit, otherwise the validation will complain about out-of-bounds input.

![A screenshot of the upper half of the consume form showing the described issue](https://github.com/grocy/grocy/assets/31102854/9447c238-542a-4e87-a3c7-cefd8beee07f)

The `/purchase` page seems to just circumvent this by forcing the selected unit to be the stock unit, but I'm not sure if this is the right solution.