### PR TITLE
Give recipe modal in meal plan space

### DIFF
--- a/public/css/grocy.css
+++ b/public/css/grocy.css
@@ -278,6 +278,13 @@ a:not([href]) {
 	z-index: 99998;
 }
 
+/* Give recipe modal in meal plan space for Ingredients/Preparation side-by-side */
+@media (min-width: 992px) {
+	.modal-xl {
+		max-width: 1100px;
+	}
+}
+
 /* Third party component customizations - DataTables */
 .dataTable td {
 	vertical-align: middle !important;


### PR DESCRIPTION
This is a tiny css addition to give recipe modal in meal plan space for Ingredients/Preparation being side-by-side.

After:

![Bildschirmfoto vom 2024-08-09 13-28-30](https://github.com/user-attachments/assets/f1e42404-fdf0-4702-ad9f-c3f70a8eff24)
![Bildschirmfoto vom 2024-08-09 13-29-04](https://github.com/user-attachments/assets/6c821462-0ab2-4e85-ac55-6f53e96785ce)

Before:
![Bildschirmfoto vom 2024-08-09 13-29-43](https://github.com/user-attachments/assets/5d6b60e1-eead-4466-a5ab-d46600cf807b)

