### PR TITLE
Make date in backup filename ISO 8601 compliant

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ set -e
 shopt -s extglob
 pushd `dirname $0` > /dev/null
 
-backupBundleFileName="backup-`date +%d-%m-%Y-%H-%M-%S`.tgz"
+backupBundleFileName="backup_`date +%Y-%m-%d_%H-%M-%S`.tgz"
 echo Making a backup of the current installation in ./data/backups/$backupBundleFileName
 mkdir -p ./data/backups > /dev/null
 touch ./data/backups/$backupBundleFileName


### PR DESCRIPTION
By making the date in backup filename ISO 8601 compliant (year-month-day) an alphabetical sort of the backups automatically will be a chronological sort of the backups. This is more convenient.

As the automatic deletion of backups older than 60 days relies on the modified date of the file (and not the filename), this will continue to work without problems.

See also: https://www.xkcd.com/1179/