### PR TITLE
Exclude self-produced product prices from spending reports

### DIFF
--- a/controllers/StockReportsController.php
+++ b/controllers/StockReportsController.php
@@ -10,6 +10,7 @@ class StockReportsController extends BaseController
 	public function Spendings(Request $request, Response $response, array $args)
 	{
 		$where = "pph.transaction_type != 'self-production'";
+
 		if (isset($request->getQueryParams()['start_date']) && isset($request->getQueryParams()['end_date']) && IsIsoDate($request->getQueryParams()['start_date']) && IsIsoDate($request->getQueryParams()['end_date']))
 		{
 			$startDate = $request->getQueryParams()['start_date'];

--- a/controllers/StockReportsController.php
+++ b/controllers/StockReportsController.php
@@ -14,12 +14,12 @@ class StockReportsController extends BaseController
 		{
 			$startDate = $request->getQueryParams()['start_date'];
 			$endDate = $request->getQueryParams()['end_date'];
-			$where = " AND pph.purchased_date BETWEEN '$startDate' AND '$endDate'";
+			$where .= " AND pph.purchased_date BETWEEN '$startDate' AND '$endDate'";
 		}
 		else
 		{
 			// Default to this month
-			$where = " AND pph.purchased_date >= DATE(DATE('now', 'localtime'), 'start of month')";
+			$where .= " AND pph.purchased_date >= DATE(DATE('now', 'localtime'), 'start of month')";
 		}
 
 		$groupBy = 'product';

--- a/controllers/StockReportsController.php
+++ b/controllers/StockReportsController.php
@@ -9,16 +9,17 @@ class StockReportsController extends BaseController
 {
 	public function Spendings(Request $request, Response $response, array $args)
 	{
+		$where = "pph.transaction_type != 'self-production'";
 		if (isset($request->getQueryParams()['start_date']) && isset($request->getQueryParams()['end_date']) && IsIsoDate($request->getQueryParams()['start_date']) && IsIsoDate($request->getQueryParams()['end_date']))
 		{
 			$startDate = $request->getQueryParams()['start_date'];
 			$endDate = $request->getQueryParams()['end_date'];
-			$where = "pph.purchased_date BETWEEN '$startDate' AND '$endDate'";
+			$where = " AND pph.purchased_date BETWEEN '$startDate' AND '$endDate'";
 		}
 		else
 		{
 			// Default to this month
-			$where = "pph.purchased_date >= DATE(DATE('now', 'localtime'), 'start of month')";
+			$where = " AND pph.purchased_date >= DATE(DATE('now', 'localtime'), 'start of month')";
 		}
 
 		$groupBy = 'product';

--- a/migrations/0239.sql
+++ b/migrations/0239.sql
@@ -1,0 +1,24 @@
+DROP VIEW products_price_history;
+CREATE VIEW products_price_history
+AS
+SELECT
+	sl.product_id AS id, -- Dummy, LessQL needs an id column
+	sl.product_id,
+	sl.price,
+	IFNULL(sl.edited_origin_amount, sl.amount) AS amount,
+	sl.purchased_date,
+	sl.shopping_location_id,
+	sl.transaction_type
+FROM (
+	SELECT sl.*, CASE WHEN sl.transaction_type = 'stock-edit-new' THEN see.edited_origin_amount END AS edited_origin_amount
+	FROM stock_log sl
+	LEFT JOIN stock_edited_entries see
+		ON sl.stock_id = see.stock_id
+) sl
+WHERE sl.undone = 0
+	AND (
+		(sl.transaction_type IN ('purchase', 'inventory-correction', 'self-production') AND sl.stock_id NOT IN (SELECT stock_id FROM stock_edited_entries)) -- Unedited origin entries
+		OR (sl.transaction_type = 'stock-edit-new' AND sl.id IN (SELECT stock_log_id_of_newest_edited_entry FROM stock_edited_entries)) -- Edited origin entries => take the newest "stock-edit-new" one
+	)
+	AND IFNULL(sl.price, 0) > 0
+	AND IFNULL(sl.amount, 0) > 0;


### PR DESCRIPTION
Possible solution to #2595 which I think achieves what you mentioned in Reddit

> Spontaneously I'd also say self produced products should simply be excluded from that report

The spending report uses the `products_price_history` view. By adding the `transaction_type` to that view, we can exclude the `self-production` transactions from the spending report queries.


### Testing
I tested the spending report view to check it was working as expected, and the product price history endpoint by visiting the Purchase/Inventory views.

The endpoint that returns the products price history only returns a subset the properties, so there wasn't any change introduced to it. For example, if you go to the inventory and select the produced product, you would still see its price.

```
$rows = $this->getDatabase()->products_price_history()->where('product_id = :1', $productId)->orderBy('purchased_date', 'DESC');
        foreach ($rows as $row)
        {
            $returnData[] = [
                'date' => $row->purchased_date,
                'price' => $row->price,
                'shopping_location' => FindObjectInArrayByPropertyValue($shoppingLocations, 'id', $row->shopping_location_id)
            ];
        }
```

And there's also the products_last_purchased view which wasn't changed either. I guess one could argue that the price for self produced transactions could be ignored in there, but I didn't want to add that to the discussion when the issue is about the spending report.

```sql
DROP VIEW products_last_purchased;
CREATE VIEW products_last_purchased
AS
SELECT
    1 AS id, 
-- Dummy, LessQL needs an id column
    sl.product_id,
    sl.amount,
    sl.best_before_date,
    sl.purchased_date,
    sl.location_id,
    sl.shopping_location_id,
    IFNULL((SELECT price FROM products_price_history WHERE product_id = sl.product_id ORDER BY purchased_date DESC LIMIT 1), 0) AS price
FROM stock_log sl
....
```