### PR TITLE
Changed dialog size to display API key delete dialog correctly

### DIFF
--- a/public/viewjs/manageapikeys.js
+++ b/public/viewjs/manageapikeys.js
@@ -34,6 +34,7 @@ $(document).on('click', '.apikey-delete-button', function(e)
 	bootbox.confirm({
 		message: __t('Are you sure to delete API key "%s"?', objectName),
 		closeButton: false,
+		size: 'large',
 		buttons: {
 			confirm: {
 				label: __t('Yes'),


### PR DESCRIPTION
The api key was too long for the dialog

Before:

![image](https://github.com/user-attachments/assets/3e4f8fb8-ef5f-40a6-9105-4bf9dde3821e)

After:

![image](https://github.com/user-attachments/assets/c7519dd2-7099-4731-b46e-dc6f50a8cc0c)
