### PR TITLE
Optimized Freezing due date replacement (closes #1880)

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -621,7 +621,22 @@ class StockApiController extends BaseApiController
 		try
 		{
 			$productId = $this->getStockService()->GetProductIdFromBarcode($args['barcode']);
-			return $this->ApiResponse($response, $this->getStockService()->GetProductDetails($productId));
+			$product_data = $this->getStockService()->GetProductDetails($productId);
+			
+			if (Grocycode::Validate($args['barcode']))
+			{
+				$gc = new Grocycode($args['barcode']);
+
+				if ($gc->GetExtraData())
+				{
+					$stock_data = $this->getDatabase()->stock()->where('stock_id', $gc->GetExtraData()[0])->fetch();
+					$data = $product_data + ['stock_entry' => $stock_data];
+				} else {
+					$data = $product_data + ['stock_entry' => null];
+				}
+			}
+
+			return $this->ApiResponse($response, $data);
 		}
 		catch (\Exception $ex)
 		{

--- a/localization/de/strings.po
+++ b/localization/de/strings.po
@@ -2045,6 +2045,9 @@ msgstr ""
 msgid "-1 means that this product will be never overdue"
 msgstr "-1 bedeutet, dass dieses Produkt niemals überfällig ist"
 
+msgid "0 means that the due date will not be replaced"
+msgstr "0 bedeutet, dass das Fälligkeitsdatum beibehalten wird"
+
 msgid "Default due days"
 msgstr "Standardfälligkeitstage"
 

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -1823,6 +1823,9 @@ msgstr ""
 msgid "-1 means that this product will be never overdue"
 msgstr ""
 
+msgid "0 means that the due date will not be replaced"
+msgstr ""
+
 msgid "Default due days"
 msgstr ""
 

--- a/services/StockService.php
+++ b/services/StockService.php
@@ -1272,6 +1272,10 @@ class StockService extends BaseService
 					{
 						$newBestBeforeDate = date('2999-12-31');
 					}
+                    elseif ($productDetails->product->default_best_before_days_after_freezing == 0)
+                    {       
+                        $newBestBeforeDate = $stockEntry->best_before_date;
+                    }
 					else
 					{
 						$newBestBeforeDate = date('Y-m-d', strtotime('+' . $productDetails->product->default_best_before_days_after_freezing . ' days'));

--- a/views/productform.blade.php
+++ b/views/productform.blade.php
@@ -317,7 +317,7 @@
 			'label' => 'Default due days after freezing',
 			'min' => -1,
 			'value' => $value,
-			'hint' => $__t('On moving this product to a freezer location (so when freezing it), the due date will be replaced by today + this amount of days') . ' (' . $__t('-1 means that this product will be never overdue') . ')'
+			'hint' => $__t('On moving this product to a freezer location (so when freezing it), the due date will be replaced by today + this amount of days') . ' (' . $__t('-1 means that this product will be never overdue') . '; ' . $__t('0 means that the due date will not be replaced') . ')'
 			))
 
 			@php if($mode == 'edit') { $value = $product->default_best_before_days_after_thawing; } else { $value = 0; } @endphp


### PR DESCRIPTION
## Current State
Currently, as mentioned in Issue #1880 , as soon as a product is moved to a freezing location, the due date will be recalculated with the value of  `default_best_before_days_after_freezing`.

## Changes
To prevent this from happening a extra condition was added to the `TransferProduct` function. With this change, if the value of `default_best_before_days_after_freezing` is set to 0, the due date wont't be replaced upon transfering a stock item to a freezing location.

## Testing
![testing](https://github.com/user-attachments/assets/5ddd3c41-aa88-4c03-8c18-e3a6f2960962)
1. The Product was created with 10 Items in _Vorratsraum_. 
2. Product on position 1 was moved with `default_best_before_days_after_freezing = 3`
3. Product on position 3 was moved with `default_best_before_days_after_freezing = 0`
4. Product on position 4 was moved with  `default_best_before_days_after_freezing = -1`

### Authors
@w00h, @chilluniverse
