### PR TITLE
Make labels on login form point to correct inputs

### DIFF
--- a/views/login.blade.php
+++ b/views/login.blade.php
@@ -15,7 +15,7 @@
 			novalidate>
 
 			<div class="form-group">
-				<label for="name">{{ $__t('Username') }}</label>
+				<label for="username">{{ $__t('Username') }}</label>
 				<input type="text"
 					class="form-control"
 					required
@@ -24,7 +24,7 @@
 			</div>
 
 			<div class="form-group">
-				<label for="name">{{ $__t('Password') }}</label>
+				<label for="password">{{ $__t('Password') }}</label>
 				<input type="password"
 					class="form-control"
 					required


### PR DESCRIPTION
I noticed this because I'm writing a playwright test for Grocy and the `get_by_label` selector was not working. Now it's working.