### PR TITLE
Fix Location Content Sheet filter checkbox

### DIFF
--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -93,7 +93,8 @@ class StockController extends BaseController
 			'products' => $this->getDatabase()->products()->where('active = 1')->orderBy('name', 'COLLATE NOCASE'),
 			'quantityunits' => $this->getDatabase()->quantity_units()->orderBy('name', 'COLLATE NOCASE'),
 			'locations' => $this->getDatabase()->locations()->orderBy('name', 'COLLATE NOCASE'),
-			'currentStockLocationContent' => $this->getStockService()->GetCurrentStockLocationContent(isset($request->getQueryParams()['include_out_of_stock']))
+			'currentStockLocationContent' => $this->getStockService()->GetCurrentStockLocationContent(isset($request->getQueryParams()['include_out_of_stock'])),
+			'includeOutOfStockProductsAtTheDefaultLocation' => isset($request->getQueryParams()['include_out_of_stock'])
 		]);
 	}
 

--- a/views/locationcontentsheet.blade.php
+++ b/views/locationcontentsheet.blade.php
@@ -40,7 +40,7 @@
 		<input class="form-check-input custom-control-input"
 			type="checkbox"
 			id="include-out-of-stock"
-			checked>
+                        @if(!$includeOutOfStockProductsAtTheDefaultLocation) checked @endif>
 		<label class="form-check-label custom-control-label"
 			for="include-out-of-stock">
 			{{ $__t('Show only in stock products') }}


### PR DESCRIPTION
Previously, the query parameter functioned as expected, but the checkbox always appeared checked. Additionally, clicking the checkbox would always result in the "unchecked" state despite remaining visually checked.

This adds the required context to the controller and an if directive to the checkbox's checked attribute in the view to match.

If you don't care for my particular style/implementation, feel free to just close this out and implement it how you feel is best. It's a two-liner and isn't worth anyone's time to go through rounds of iteration over. Just offering a fix and pointing out the issue.