### PR TITLE
FIX: Issue with __image_url when it contains HTTP params (ie, ?<params>)

### DIFF
--- a/services/StockService.php
+++ b/services/StockService.php
@@ -626,7 +626,7 @@ class StockService extends BaseService
 					{
 						$webClient = new Client();
 						$response = $webClient->request('GET', $pluginOutput['__image_url'], ['headers' => ['User-Agent' => 'Grocy/' . $this->getApplicationService()->GetInstalledVersion()->Version . ' (https://grocy.info)']]);
-						$fileName = $pluginOutput['__barcode'] . '.' . pathinfo($pluginOutput['__image_url'], PATHINFO_EXTENSION);
+						$fileName = $pluginOutput['__barcode'] . '.' . pathinfo(explode('?', $pluginOutput['__image_url'])[0], PATHINFO_EXTENSION);
 						file_put_contents($this->getFilesService()->GetFilePath('productpictures', $fileName), $response->getBody());
 						$productData['picture_file_name'] = $fileName;
 					}


### PR DESCRIPTION
I had an error using a Plugin to obtain the product information from the store where I bought it.

The issue is that the store API returns the image URL with some size HTTP params.
Eg: "productX.jpg?sw=180&sh=180"

This was messing with grocy. 
The image is saved OK (with the added params on its filename), but it can't be used.

This commit make sure Grocy only uses the base URL when creating the filename for the product image from the __image_url. 

When the __image_url contains HTTP params, it will split the URL on the '?' character and only use the 1st part.