### PR TITLE
fix(openapi): volatile is not an array, it's an object

### DIFF
--- a/grocy.openapi.json
+++ b/grocy.openapi.json
@@ -1617,10 +1617,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/CurrentVolatilStockResponse"
-									}
+									"$ref": "#/components/schemas/CurrentVolatilStockResponse"
 								}
 							}
 						}


### PR DESCRIPTION
While developing a basic application using OpenAPI, I noticed that volatile did not have the correct type.
