### PR TITLE
Improve the update shell script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,32 +1,33 @@
 #!/bin/bash
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Start updating Grocy"
 
 GROCY_RELEASE_URL=https://releases.grocy.info/latest
-
-
-echo Start updating Grocy
 
 set -e
 shopt -s extglob
 pushd `dirname $0` > /dev/null
 
 backupBundleFileName="backup_`date +%Y-%m-%d_%H-%M-%S`.tgz"
-echo Making a backup of the current installation in ./data/backups/$backupBundleFileName
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Making a backup of the current installation in ./data/backups/$backupBundleFileName"
 mkdir -p ./data/backups > /dev/null
 touch ./data/backups/$backupBundleFileName
 tar -zcvf ./data/backups/$backupBundleFileName --exclude ./data/backups . > /dev/null
 find ./data/backups/*.tgz -mtime +60 -type f -delete
 
-echo Deleting everything except ./data and this script
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Deleting everything except ./data and this script"
 rm -rf !(data|update.sh) > /dev/null
 
-echo Downloading latest release
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Downloading latest release"
 rm -f ./grocy-latest.zip > /dev/null
 wget $GROCY_RELEASE_URL -q --show-progress -O ./grocy-latest.zip > /dev/null
 
-echo Unzipping latest release
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Unzipping latest release"
 unzip -o ./grocy-latest.zip > /dev/null
 rm -f ./grocy-latest.zip > /dev/null
 
 popd > /dev/null
 
-echo Finished updating Grocy
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Make sure the new update.sh script is executable"
+chmod +x ./update.sh
+
+echo "[$(date '+%d/%m/%Y %H:%M:%S')] Finished updating Grocy"


### PR DESCRIPTION
Hi,

i have here an improved update shell script adding additional log information as well as making sure the update script is beeing marked executable after the update has been run too
![image](https://github.com/user-attachments/assets/f4467aef-c1f3-4961-beca-8922e68be647)

![image](https://github.com/user-attachments/assets/4eba97bf-4a4a-4fc5-82f1-c330141b7047)

I could also move the settings like backup folder and release URL into a dedicated setting file. And thereby also could make it possible to configure to move the backup path outside of the web root, by default we of course would still fallback to the data folder. But please let me know when you want me to include this change into my PR or you say its to complicated.