### PR TITLE
Optimizing website

### DIFF
--- a/views/mealplan.blade.php
+++ b/views/mealplan.blade.php
@@ -73,7 +73,6 @@
 	var weekRecipe = {!! json_encode($weekRecipe) !!};
 
 	Grocy.QuantityUnits = {!! json_encode($quantityUnits) !!};
-	Grocy.QuantityUnitConversionsResolved = {!! json_encode($quantityUnitConversionsResolved) !!};
 
 	Grocy.MealPlanFirstDayOfWeek = '{{ GROCY_MEAL_PLAN_FIRST_DAY_OF_WEEK }}';
 </script>

--- a/views/recipes.blade.php
+++ b/views/recipes.blade.php
@@ -34,7 +34,6 @@
 @section('content')
 <script>
 	Grocy.QuantityUnits = {!! json_encode($quantityUnits) !!};
-	Grocy.QuantityUnitConversionsResolved = {!! json_encode($quantityUnitConversionsResolved) !!};
 </script>
 
 <div class="row">


### PR DESCRIPTION
I've detected two sites where a variable is loading but never used.
This is $quantityUnitConversionsResolved, it will also be ok to remove from querying the database for the data but for now I'm trying to understand all the code.

I've observed that when a user has defined lots of quantity units (with their conversions), this variable takes a lot of space (in my case it reduced the page load from 35mb to 300k just by removing it).

I'll look the use cases, for a future refactoring, because it's not optimal to have the quantity units table by every single product and download it every time.