### PR TITLE
README.md: add required php modules for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ See the website for more installation guides and troubleshooting help. &rarr; [h
 ### Platform support
 
 - PHP 8.2 or 8.3 (with SQLite 3.34.0+)
-  - Required PHP extensions: `fileinfo`, `pdo_sqlite`, `gd`, `ctype`, `intl`, `zlib`, `mbstring`
+  - Required PHP extensions:
+      - `ctype`
+      - `fileinfo`
+      - `gd`
+      - `iconv`
+      - `intl`
+      - `mbstring`
+      - `pdo_sqlite`
+      - `tokenizer`
+      - `zlib`
   - _Recommendation: Benchmark tests showed that e.g. unit conversion handling is up to 5 times faster when using a more recent (3.39.4+) SQLite version._
 - Recent Firefox, Chrome or Edge
 


### PR DESCRIPTION
Fix the following errors:
Unable to run Grocy: PHP module 'iconv' not installed, but required.
Unable to run Grocy: PHP module 'tokenizer' not installed, but required.