### PR TITLE
#2739 Send CloseLastModal from stockentry and stockoverview on Ready message handler rather than from purchase modal.

### DIFF
--- a/public/viewjs/purchase.js
+++ b/public/viewjs/purchase.js
@@ -178,7 +178,6 @@ $('#save-purchase-button').on('click', function(e)
 							window.parent.postMessage(WindowMessageBag("AfterItemAdded", GetUriParam("listitemid")), Grocy.BaseUrl);
 							window.parent.postMessage(WindowMessageBag("ShowSuccessMessage", successMessage), Grocy.BaseUrl);
 							window.parent.postMessage(WindowMessageBag("Ready"), Grocy.BaseUrl);
-							window.parent.postMessage(WindowMessageBag("CloseLastModal"), Grocy.BaseUrl);
 						});
 					}
 					else

--- a/public/viewjs/stockentries.js
+++ b/public/viewjs/stockentries.js
@@ -322,6 +322,9 @@ $(window).on("message", function(e)
 		{
 			RefreshStockEntryRow($(this).attr("data-stockrow-id"));
 		});
+	} else if (data.Message == "Ready")
+	{
+		window.parent.postMessage(WindowMessageBag("CloseLastModal"), Grocy.BaseUrl);
 	};
 });
 

--- a/public/viewjs/stockoverview.js
+++ b/public/viewjs/stockoverview.js
@@ -416,5 +416,8 @@ $(window).on("message", function(e)
 	{
 		RefreshProductRow(data.Payload);
 		RefreshStatistics();
-	}
+	} else if (data.Message == "Ready")
+	{
+		window.parent.postMessage(WindowMessageBag("CloseLastModal"), Grocy.BaseUrl);
+	};
 });


### PR DESCRIPTION
This resolves #2739 however I feel it is a blunt fix that burdens any future users of the purchase modal with the responsibility of closing the modal when its job is done.

Perhaps a better fix might be for the purchase modal to consider the current page before sending the CloseLastModal message?

I.E.

```
window.parent.postMessage(WindowMessageBag("AfterItemAdded", GetUriParam("listitemid")), Grocy.BaseUrl);
window.parent.postMessage(WindowMessageBag("ShowSuccessMessage", successMessage), Grocy.BaseUrl);
window.parent.postMessage(WindowMessageBag("Ready"), Grocy.BaseUrl);
if (window.parent.document.getElementById("shoppinglist-table") == null)
{
	window.parent.postMessage(WindowMessageBag("CloseLastModal"), Grocy.BaseUrl);
};
```

Both approaches work. @berrnd which do you prefer?

Test approach:
Navigate to shopping list.
Add at least two products to shopping list.
Stock actions -> Add all list items to stock.
Click OK. Ensure modal does not close.
Close modal.
Click "Add this item to stock" on a row in the shopping list.
Click OK. Ensure modal does close.
Navigate to stock overview page.
Click ⋮-> Purchase on a row in the stock list
Enter amount, click OK, ensure modal does close.
Navigate to stock entries page.
Click ⋮-> Purchase on a row in the stock entries list
Enter amount, click OK, ensure modal does close.