### PR TITLE
Support associating a Shopping List with a Store

### DIFF
--- a/controllers/StockApiController.php
+++ b/controllers/StockApiController.php
@@ -20,13 +20,18 @@ class StockApiController extends BaseApiController
 			$requestBody = $this->GetParsedAndFilteredRequestBody($request);
 
 			$listId = 1;
-
 			if (array_key_exists('list_id', $requestBody) && !empty($requestBody['list_id']) && is_numeric($requestBody['list_id']))
 			{
 				$listId = intval($requestBody['list_id']);
 			}
 
-			$this->getStockService()->AddMissingProductsToShoppingList($listId);
+			$checkDefaultShoppingLocation = false;
+			if (array_key_exists('check_default_shopping_location', $requestBody) && filter_var($requestBody['check_default_shopping_location'], FILTER_VALIDATE_BOOLEAN) !== false)
+			{
+				$checkDefaultShoppingLocation = boolval($requestBody['check_default_shopping_location']);
+			}
+
+			$this->getStockService()->AddMissingProductsToShoppingList($listId, $checkDefaultShoppingLocation);
 			return $this->EmptyApiResponse($response);
 		}
 		catch (\Exception $ex)

--- a/controllers/StockController.php
+++ b/controllers/StockController.php
@@ -441,6 +441,7 @@ class StockController extends BaseController
 		{
 			return $this->renderPage($response, 'shoppinglistform', [
 				'mode' => 'create',
+				'shoppinglocations' => $this->getDatabase()->shopping_locations()->where('active = 1')->orderBy('name', 'COLLATE NOCASE'),
 				'userfields' => $this->getUserfieldsService()->GetFields('shopping_lists')
 			]);
 		}
@@ -449,6 +450,7 @@ class StockController extends BaseController
 			return $this->renderPage($response, 'shoppinglistform', [
 				'shoppingList' => $this->getDatabase()->shopping_lists($args['listId']),
 				'mode' => 'edit',
+				'shoppinglocations' => $this->getDatabase()->shopping_locations()->where('active = 1')->orderBy('name', 'COLLATE NOCASE'),
 				'userfields' => $this->getUserfieldsService()->GetFields('shopping_lists')
 			]);
 		}

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -2470,3 +2470,6 @@ msgstr ""
 
 msgid "List actions"
 msgstr ""
+
+msgid "Add products that are below defined min. stock amount from matching store"
+msgstr ""

--- a/migrations/0254.sql
+++ b/migrations/0254.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shopping_lists
+ADD shopping_location_id REFERENCES shopping_locations(id);

--- a/public/viewjs/shoppinglist.js
+++ b/public/viewjs/shoppinglist.js
@@ -156,6 +156,20 @@ $(document).on('click', '#add-products-below-min-stock-amount', function(e)
 	);
 });
 
+$(document).on('click', '#add-products-below-min-stock-amount-by-shopping-location', function(e)
+	{
+	Grocy.Api.Post('stock/shoppinglist/add-missing-products', { "list_id": $("#selected-shopping-list").val(), "check_default_shopping_location": true },
+		function(result)
+		{
+			window.location.href = U('/shoppinglist?list=' + $("#selected-shopping-list").val());
+		},
+		function(xhr)
+		{
+			console.error(xhr);
+		}
+	);
+});
+
 $(document).on('click', '#add-overdue-expired-products', function(e)
 {
 	Grocy.Api.Post('stock/shoppinglist/add-overdue-products', { "list_id": $("#selected-shopping-list").val() },

--- a/views/shoppinglist.blade.php
+++ b/views/shoppinglist.blade.php
@@ -144,6 +144,9 @@ $listItem->last_price_total = $listItem->price * $listItem->amount;
 						<a id="add-products-below-min-stock-amount"
 							class="dropdown-item"
 							href="#">{{ $__t('Add products that are below defined min. stock amount') }}</a>
+						<a id="add-products-below-min-stock-amount-by-shopping-location"
+							class="dropdown-item"
+							href="#">{{ $__t('Add products that are below defined min. stock amount from matching store') }}</a>
 						@endif
 						<a id="add-overdue-expired-products"
 							class="dropdown-item"

--- a/views/shoppinglistform.blade.php
+++ b/views/shoppinglistform.blade.php
@@ -41,6 +41,20 @@
 				<div class="invalid-feedback">{{ $__t('A name is required') }}</div>
 			</div>
 
+			@php $prefillById = ''; if($mode=='edit') { $prefillById = $shoppingList->shopping_location_id; } @endphp
+			@if(GROCY_FEATURE_FLAG_STOCK_PRICE_TRACKING)
+			@include('components.shoppinglocationpicker', array(
+			'label' => 'Associated store',
+			'prefillById' => $prefillById,
+			'shoppinglocations' => $shoppinglocations
+			))
+			@else
+			<input type="hidden"
+				name="shopping_location_id"
+				id="shopping_location_id"
+				value="1">
+			@endif
+
 			@include('components.userfieldsform', array(
 			'userfields' => $userfields,
 			'entity' => 'shopping_lists'


### PR DESCRIPTION
Good morning!

Since this feature would greatly simplify the effort of adopting Grocy in my family, I tried to put together a PR that closes #1357 allowing to associate a Shopping List with a specific Store and then pull products that are below the specified amount only if linked to the same one.

In detail, this PR:
- Adds a new (optional) `Associated Store` field to Shopping Lists;
- Changes the `/stock/shoppinglist/add-missing-product` API route to support a new (optional) `check_default_shopping_location` body parameter that, if set to `true`, only adds to the list products from the associated Store;
- Adds a new frontend button that calls the `/stock/shoppinglist/add-missing-product` endpoint with the `check_default_shopping_location` body parameter enabled.

Let me know if the code looks good enough or if changes are needed before merging.