### PR TITLE
Replace "command" tests with regex and fix broken commands

### DIFF
--- a/public/viewjs/components/datetimepicker.js
+++ b/public/viewjs/components/datetimepicker.js
@@ -150,7 +150,7 @@ Grocy.Components.DateTimePicker.GetInputElement().on('keyup', function(e)
 		Grocy.Components.DateTimePicker.SetValue(moment('2999-12-31 23:59:59').format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 4 && !(Number.parseInt(value) > centuryStart && Number.parseInt(value) < centuryEnd)) // Shorthand for MMDD
+	else if (/{[0-9]{4}}/.test(value) && !(Number.parseInt(value) > centuryStart && Number.parseInt(value) < centuryEnd)) // Shorthand for MMDD
 	{
 		var date = moment((new Date()).getFullYear().toString() + value);
 		if (date.isBefore(moment()))
@@ -160,18 +160,18 @@ Grocy.Components.DateTimePicker.GetInputElement().on('keyup', function(e)
 		Grocy.Components.DateTimePicker.SetValue(date.format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 8 && $.isNumeric(value)) // Shorthand for YYYYMMDD
+	else if (/[0-9]{8}/.test(value)) // Shorthand for YYYYMMDD
 	{
 		Grocy.Components.DateTimePicker.SetValue(value.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 7 && $.isNumeric(value.substring(0, 6)) && (value.substring(6, 7).toLowerCase() === "e" || value.substring(6, 7).toLowerCase() === "+")) // Shorthand for YYYYMM[e/+]
+	else if (/[0-9]{6}[e+]/.test(value)) // Shorthand for YYYYMM[e/+]
 	{
 		var date = moment(value.substring(0, 4) + "-" + value.substring(4, 6) + "-01").endOf("month");
 		Grocy.Components.DateTimePicker.SetValue(date.format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if ((value.startsWith("+") || value.startsWith("-")) && (lastCharacter == "d" || lastCharacter == "m" || lastCharacter == "y")) // Shorthand for [+/-]n[d/m/y]
+	else if (/[+-][0-9]+[dmy]/.test(value)) // Shorthand for [+/-]n[d/m/y]
 	{
 		var n = Number.parseInt(value.substring(1, value.length - 1));
 		if (value.startsWith("-"))

--- a/public/viewjs/components/datetimepicker2.js
+++ b/public/viewjs/components/datetimepicker2.js
@@ -150,7 +150,7 @@ Grocy.Components.DateTimePicker2.GetInputElement().on('keyup', function(e)
 		Grocy.Components.DateTimePicker2.SetValue(moment('2999-12-31 23:59:59').format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 4 && !(Number.parseInt(value) > centuryStart && Number.parseInt(value) < centuryEnd)) // Shorthand for MMDD
+	else if (/{[0-9]{4}}/.test(value) && !(Number.parseInt(value) > centuryStart && Number.parseInt(value) < centuryEnd)) // Shorthand for MMDD
 	{
 		var date = moment((new Date()).getFullYear().toString() + value);
 		if (date.isBefore(moment()))
@@ -160,18 +160,18 @@ Grocy.Components.DateTimePicker2.GetInputElement().on('keyup', function(e)
 		Grocy.Components.DateTimePicker2.SetValue(date.format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 8 && $.isNumeric(value)) // Shorthand for YYYYMMDD
+	else if (/[0-9]{8}/.test(value)) // Shorthand for YYYYMMDD
 	{
 		Grocy.Components.DateTimePicker2.SetValue(value.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3'), inputElement);
 		nextInputElement.focus();
 	}
-	else if (value.length === 7 && $.isNumeric(value.substring(0, 6)) && (value.substring(6, 7).toLowerCase() === "e" || value.substring(6, 7).toLowerCase() === "+")) // Shorthand for YYYYMM[e/+]
+	else if (/[0-9]{6}[e+]/.test(value)) // Shorthand for YYYYMM[e/+]
 	{
 		var date = moment(value.substring(0, 4) + "-" + value.substring(4, 6) + "-01").endOf("month");
 		Grocy.Components.DateTimePicker2.SetValue(date.format(format), inputElement);
 		nextInputElement.focus();
 	}
-	else if ((value.startsWith("+") || value.startsWith("-")) && (lastCharacter == "d" || lastCharacter == "m" || lastCharacter == "y")) // Shorthand for [+/-]n[d/m/y]
+	else if (/[+-][0-9]+[dmy]/.test(value)) // Shorthand for [+/-]n[d/m/y]
 	{
 		var n = Number.parseInt(value.substring(1, value.length - 1));
 		if (value.startsWith("-"))


### PR DESCRIPTION
Fixes https://github.com/grocy/grocy/issues/2806

Replaces "command" detection logic with regex and fixes bug where user could not input commands of greater than length 4.

[BUG]
Cannot trigger the following:
YYYYMMDD gets expanded to the proper ISO-8601 notation

[Fix Evidence]
https://github.com/user-attachments/assets/bbf0991d-39a1-421f-96f8-db5177c3c372

[BUG]
Cannot trigger the following:
YYYYMMe or YYYYMM+ gets expanded to the end of the given month in the given year in proper notation

[Fix Evidence]
https://github.com/user-attachments/assets/37a6459d-e1f0-4b97-bbc4-296ba87055df

[BUG]
Cannot trigger the following past 100:
[+/-]n[d/m/y] gets expanded to a date relative to today, while adding (+) or subtracting (-) the number of days/months/years, in proper notation

[Fix Evidence]
https://github.com/user-attachments/assets/26177a00-9c95-4f0e-980f-adb41e665c48