### PR TITLE
Add download SQL database button

### DIFF
--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Grocy\Controllers;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ExportController extends BaseController
+{
+	public function DownloadSql(Request $request, Response $response, array $args) {
+		$databasePath = GROCY_DATAPATH . '/grocy.db';
+
+		if (file_exists($databasePath))
+		{
+			$response = $response->withHeader('Content-Type', 'application/octet-stream');
+			$response = $response->withHeader('Content-Disposition', 'attachment; filename="grocy.db"');
+			$response = $response->withHeader('Content-Length', filesize($databasePath));
+			$response->getBody()->write(file_get_contents($databasePath));
+			return $response;
+		}
+		else
+		{
+			return $response->withStatus(404, 'Database file not found');
+		}
+	}
+}

--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -12,8 +12,10 @@ class ExportController extends BaseController
 
 		if (file_exists($databasePath))
 		{
+			$dateTimeString = date('Y-m-d-H:i:s');
+
 			$response = $response->withHeader('Content-Type', 'application/octet-stream');
-			$response = $response->withHeader('Content-Disposition', 'attachment; filename="grocy.db"');
+			$response = $response->withHeader('Content-Disposition', "attachment; filename=\"grocy-$dateTimeString.db\"");
 			$response = $response->withHeader('Content-Length', filesize($databasePath));
 			$response->getBody()->write(file_get_contents($databasePath));
 			return $response;

--- a/localization/strings.pot
+++ b/localization/strings.pot
@@ -318,6 +318,9 @@ msgstr ""
 msgid "REST API browser"
 msgstr ""
 
+msgid "Download SQL database"
+msgstr ""
+
 msgid "API keys"
 msgstr ""
 

--- a/routes.php
+++ b/routes.php
@@ -241,7 +241,10 @@ $app->group('/api', function (RouteCollectorProxy $group)
 
 	// Calendar
 	$group->get('/calendar/ical', '\Grocy\Controllers\CalendarApiController:Ical')->setName('calendar-ical');
-	$group->get('/calendar/ical/sharing-link', '\Grocy\Controllers\CalendarApiController:IcalSharingLink');
+	$group->get('/calendar/ical/sharing-link', '\Grocy\Controllers\CalendarApiController:IcalSharingLink');#
+
+	// Export routes
+	$group->get('/export/sql', '\Grocy\Controllers\ExportController:DownloadSql');
 })->add(JsonMiddleware::class);
 
 // Handle CORS preflight OPTIONS requests

--- a/routes.php
+++ b/routes.php
@@ -241,7 +241,7 @@ $app->group('/api', function (RouteCollectorProxy $group)
 
 	// Calendar
 	$group->get('/calendar/ical', '\Grocy\Controllers\CalendarApiController:Ical')->setName('calendar-ical');
-	$group->get('/calendar/ical/sharing-link', '\Grocy\Controllers\CalendarApiController:IcalSharingLink');#
+	$group->get('/calendar/ical/sharing-link', '\Grocy\Controllers\CalendarApiController:IcalSharingLink');
 
 	// Export routes
 	$group->get('/export/sql', '\Grocy\Controllers\ExportController:DownloadSql');

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -675,7 +675,7 @@
 						<a class="dropdown-item discrete-link"
 							href="{{ $U('/barcodescannertesting') }}"><i class="fa-solid fa-fw fa-barcode"></i>&nbsp;{{ $__t('Barcode scanner testing') }}</a>
 						<a class="dropdown-item discrete-link"
-							href="{{ $U('/api/export/sql') }}"><i class="fa-solid fa-fw fa-database"></i>&nbsp;{{ $__t('Download database') }}</a>
+							href="{{ $U('/api/export/sql') }}"><i class="fa-solid fa-fw fa-database"></i>&nbsp;{{ $__t('Download SQL database') }}</a>
 						<div class="dropdown-divider"></div>
 						<a class="dropdown-item discrete-link show-as-dialog-link"
 							data-dialog-type="wider"

--- a/views/layout/default.blade.php
+++ b/views/layout/default.blade.php
@@ -674,6 +674,8 @@
 							href="{{ $U('/api') }}"><i class="fa-solid fa-fw fa-book"></i>&nbsp;{{ $__t('REST API browser') }}</a>
 						<a class="dropdown-item discrete-link"
 							href="{{ $U('/barcodescannertesting') }}"><i class="fa-solid fa-fw fa-barcode"></i>&nbsp;{{ $__t('Barcode scanner testing') }}</a>
+						<a class="dropdown-item discrete-link"
+							href="{{ $U('/api/export/sql') }}"><i class="fa-solid fa-fw fa-database"></i>&nbsp;{{ $__t('Download database') }}</a>
 						<div class="dropdown-divider"></div>
 						<a class="dropdown-item discrete-link show-as-dialog-link"
 							data-dialog-type="wider"


### PR DESCRIPTION
Adds an option to download `data/grocy.db` directly from the browser for a quick backup.
<img width="250" height="186" alt="image" src="https://github.com/user-attachments/assets/9a9fef2b-19ba-4285-8266-11ee1ae2cf2b" />

Related #129