### PR TITLE
Forbid empty username header for reverse proxy authentication

### DIFF
--- a/middleware/ReverseProxyAuthMiddleware.php
+++ b/middleware/ReverseProxyAuthMiddleware.php
@@ -43,9 +43,14 @@ class ReverseProxyAuthMiddleware extends AuthMiddleware
 			if (count($username) !== 1)
 			{
 				// Invalid configuration of Proxy
-				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing or invalid');
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is missing');
 			}
 			$username = $username[0];
+			if (strlen($username) === 0)
+			{
+				// Header is empty
+				throw new \Exception('ReverseProxyAuthMiddleware: ' . GROCY_REVERSE_PROXY_AUTH_HEADER . ' header is invalid');
+			}
 		}
 
 		$user = $db->users()->where('username', $username)->fetch();


### PR DESCRIPTION
Consider the case where a Grocy user wants to use reverse proxy authentication OR authentication with an API key.

By default, authenticating reverse proxy will unconditionally perform user authentication, before allowing a request to be passed to Grocy which will verify an API key, rendering them virtually useless. So the proxy needs to be configured not to perform authentication in certain cases, for example the presence of the `Grocy-Api-Key` HTTP header, or the path being a subdirectory of `/api/`.

It can however be tricky to configure this though. For example, nginx does not allow conditional authentication, or conditional header setting. In those cases, when the condition is met, the username header would still be returned, albeit empty. Grocy will then create an user with empty username (not normally possible). It default to having all permissions, and while most are removable, reading chores/stock/etc. do not seem to be, and would thus be public.

This returns an error when the username is empty, to accomodate for those cases.