### PR TITLE
Fix 'Due Soon Days' User Settings for Chores and Batteries

### DIFF
--- a/views/batteriessettings.blade.php
+++ b/views/batteriessettings.blade.php
@@ -17,7 +17,7 @@
 
 		@include('components.numberpicker', array(
 		'id' => 'batteries_due_soon_days',
-		'additionalAttributes' => 'data-setting-key=" batteries_due_soon_days"', 'label'=> 'Due soon days',
+		'additionalAttributes' => 'data-setting-key="batteries_due_soon_days"', 'label'=> 'Due soon days',
 		'min' => 0,
 		'additionalCssClasses' => 'user-setting-control',
 		'hint' => $__t('Set to 0 to hide due soon filters/highlighting')

--- a/views/choressettings.blade.php
+++ b/views/choressettings.blade.php
@@ -13,11 +13,11 @@
 
 <div class="row">
 	<div class="col-lg-4 col-md-8 col-12">
-		<h4 ">{{ $__t('Chores overview') }}</h4>
+		<h4>{{ $__t('Chores overview') }}</h4>
 
 		@include('components.numberpicker', array(
 		'id' => 'chores_due_soon_days',
-		'additionalAttributes' => 'data-setting-key=" chores_due_soon_days"', 'label'=> 'Due soon days',
+		'additionalAttributes' => 'data-setting-key="chores_due_soon_days"', 'label'=> 'Due soon days',
 			'min' => 0,
 			'additionalCssClasses' => 'user-setting-control',
 			'hint' => $__t('Set to 0 to hide due soon filters/highlighting')


### PR DESCRIPTION
I recently set up Grocy for the first time and noticed changing the 'Due soon days' for Chores and Batteries did not persist like for other features.

I was able to reproduce on the public demo pages for both Stable and Preview, and searched but did not see any existing Issues or Pull requests referencing it here on GitHub.

The reproduction steps were:
1. Select wrench settings icon in upper-right corner
2. Choose "Batteries settings" (or "Chores settings")
3. Change the numerical value for "Due soon days"
4. Refresh the page (or select "OK")
5. The value is reset to what it was before

Thanks for creating Grocy and taking the time to review!