### PR TITLE
Adapt stock_current view to add stock_ids

### DIFF
--- a/migrations/0256.sql
+++ b/migrations/0256.sql
@@ -1,0 +1,54 @@
+DROP VIEW IF EXISTS stock_current;
+CREATE VIEW stock_current
+AS
+SELECT
+        pr.parent_product_id AS product_id,
+        GROUP_CONCAT(s.id) AS stock_ids,
+        IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id), 0) AS amount,
+        SUM(s.amount * IFNULL(qucr.factor, 1.0)) AS amount_aggregated,
+        IFNULL(ROUND((SELECT SUM(IFNULL(price,0) * amount) FROM stock WHERE product_id = pr.parent_product_id), 2), 0)  AS value,
+        MIN(s.best_before_date) AS best_before_date,
+        IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = pr.parent_product_id AND open = 1), 0) AS amount_opened,
+        IFNULL((SELECT SUM(amount) FROM stock WHERE product_id IN (SELECT sub_product_id FROM products_resolved WHERE parent_product_id = pr.parent_product_id) AND open = 1), 0) * IFNULL(qucr.factor, 1) AS amount_opened_aggregated,
+        CASE WHEN COUNT(p_sub.parent_product_id) > 0  THEN 1 ELSE 0 END AS is_aggregated_amount,
+        MAX(p_parent.due_type) AS due_type
+FROM products_resolved pr
+JOIN stock s
+        ON pr.sub_product_id = s.product_id
+JOIN products p_parent
+        ON pr.parent_product_id = p_parent.id
+        AND p_parent.active = 1
+JOIN products p_sub
+        ON pr.sub_product_id = p_sub.id
+        AND p_sub.active = 1
+LEFT JOIN cache__quantity_unit_conversions_resolved qucr
+        ON pr.sub_product_id = qucr.product_id
+        AND p_sub.qu_id_stock = qucr.from_qu_id
+        AND p_parent.qu_id_stock = qucr.to_qu_id
+GROUP BY pr.parent_product_id
+HAVING SUM(s.amount) > 0
+
+UNION
+
+-- This is the same as above but sub products not rolled up (no QU conversion and column is_aggregated_amount = 0 here)
+SELECT
+        pr.sub_product_id AS product_id,
+        GROUP_CONCAT(s.id) AS stock_ids,
+        SUM(s.amount) AS amount,
+        SUM(s.amount) AS amount_aggregated,
+        ROUND(SUM(IFNULL(s.price, 0) * s.amount), 2) AS value,
+        MIN(s.best_before_date) AS best_before_date,
+        IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = s.product_id AND open = 1), 0) AS amount_opened,
+        IFNULL((SELECT SUM(amount) FROM stock WHERE product_id = s.product_id AND open = 1), 0) AS amount_opened_aggregated,
+        0 AS is_aggregated_amount,
+        MAX(p_sub.due_type) AS due_type
+FROM products_resolved pr
+JOIN stock s
+        ON pr.sub_product_id = s.product_id
+JOIN products p_sub
+        ON pr.sub_product_id = p_sub.id
+        AND p_sub.active = 1
+WHERE pr.parent_product_id != pr.sub_product_id
+GROUP BY pr.sub_product_id
+HAVING SUM(s.amount) > 0
+/* stock_current(product_id,amount,amount_aggregated,value,best_before_date,amount_opened,amount_opened_aggregated,is_aggregated_amount,due_type) */;


### PR DESCRIPTION
Currently, using the API endpoints, we are unable to retrieve the list of stock IDs...     
The goal of this pull request is to adapt the view to add a new column that will aggregate all stock ids. This way, in the `/stock` endpoint, we are now able to know the ID of the stock entry and thus query `/stock/entry/{entryId}`.

Before that, it was not possible to know this stock entry id.

Only line 6 and 36 were added to the existing view:
```sql
        GROUP_CONCAT(s.id) AS stock_ids,
```